### PR TITLE
Optimise riboseq star

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -549,7 +549,7 @@ if (!params.skip_alignment && params.aligner == 'star_salmon') {
                 '--alignSJoverhangMin 8',
                 '--alignEndsType EndToEnd',
                 '--outFilterMismatchNmax 999',
-                '--outFilterMismatchNoverReadLmax 0.04',
+                '--outFilterMismatchNoverReadLmax 0.1',
                 '--outFilterMultimapNmax 20',
                 '-–outFilterType BySJout',
                 params.save_unaligned ? '--outReadsUnmapped Fastx' : '',

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -57,6 +57,12 @@ process {
         ]
     }
 
+    // TODO: may separate indices for RNA and riboseq reads
+
+    withName: 'STAR_GENOMEGENERATE' {
+        ext.args = '--sjdbOverhang 30'
+    }
+
     withName: 'GFFREAD' {
         ext.args   = '--keep-exon-attrs -F -T'
         publishDir = [
@@ -536,9 +542,16 @@ if (!params.skip_alignment && params.aligner == 'star_salmon') {
     process {
         withName: 'STAR_ALIGN' {
             ext.args   = { [
+                '--alignIntronMin 20',
+                '--alignIntronMax 1000000',
+                '--alignMatesGapMax 1000000',
                 '--alignSJDBoverhangMin 1',
+                '--alignSJoverhangMin 8',
                 '--alignEndsType EndToEnd',
+                '--outFilterMismatchNmax 999',
+                '--outFilterMismatchNoverReadLmax 0.04',
                 '--outFilterMultimapNmax 20',
+                '-–outFilterType BySJout',
                 params.save_unaligned ? '--outReadsUnmapped Fastx' : '',
                 '--outSAMattributes All',
                 '--outSAMstrandField intronMotif',
@@ -547,7 +560,9 @@ if (!params.skip_alignment && params.aligner == 'star_salmon') {
                 '--quantTranscriptomeBan Singleend',
                 '--readFilesCommand zcat',
                 '--runRNGseed 0',
+                '--seedSearchStartLmax 20',
                 '--twopassMode Basic',
+                '--winAnchorMultimapNmax 100',
                 params.extra_star_align_args ? params.extra_star_align_args.split("\\s(?=--)") : ''
             ].flatten().unique(false).join(' ').trim() }
             publishDir = [


### PR DESCRIPTION
<!--
# nf-core/riboseq pull request

Many thanks for contributing to nf-core/riboseq!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/riboseq/tree/master/.github/CONTRIBUTING.md)
-->

I'm leaving this PR just for records. I made a couple of attempts to improve mapping rates, and while I reduced unmapped reads, I did so at the cost of reducing uniquely mapped reads and increasing multi-mappers. We can maybe return to this later, but for now I think the mapping rates here are a feature of short read length for the technology.

QC report before these adaptations:

[multiqc_report (10).html.zip](https://github.com/nf-core/riboseq/files/14383929/multiqc_report.10.html.zip)

QC report after first commit here:

[multiqc_report (11).html.zip](https://github.com/nf-core/riboseq/files/14383939/multiqc_report.11.html.zip)

QC report after second commit here:

[multiqc_report (12).html.zip](https://github.com/nf-core/riboseq/files/14383951/multiqc_report.12.html.zip)



## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/riboseq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/riboseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
