### PR TITLE
Bump bbsplit module to prevent index overwrites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [[#12](https://github.com/nf-core/riboseq/pull/12) - Add alignment via STAR + postprocessing (([@pinin4fjords](https://github.com/pinin4fjords), review by [@maxulysse](https://github.com/maxulysse))
 - [[#32](https://github.com/nf-core/riboseq/pull/32) - Nf core template merge 2.13 (manual) ([@pinin4fjords](https://github.com/pinin4fjords), review by [@maxulysse](https://github.com/maxulysse), [@adamrtalbot](https://github.com/adamrtalbot))
 - [[#34](https://github.com/nf-core/riboseq/pull/34) - Fix order of preprocessing steps ([@pinin4fjords](https://github.com/pinin4fjords), review by [@maxulysse](https://github.com/maxulysse))
-- [[#35](https://github.com/nf-core/riboseq/pull/35) - Sortmerna: index once ([@pinin4fjords](https://github.com/pinin4fjords), review by )
+- [[#35](https://github.com/nf-core/riboseq/pull/35) - Sortmerna: index once ([@pinin4fjords](https://github.com/pinin4fjords), review by [@maxulysse](https://github.com/maxulysse))
+- [[#36](https://github.com/nf-core/riboseq/pull/36) - Bump bbsplit module to prevent index overwrites ([@pinin4fjords](https://github.com/pinin4fjords), review by [@maxulysse](https://github.com/maxulysse))
 
 Initial release of nf-core/riboseq, created with the [nf-core](https://nf-co.re/) template.
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -308,7 +308,7 @@ if (params.with_umi && !params.skip_umi_extract) {
 if (!params.skip_bbsplit) {
     process {
         withName: 'BBMAP_BBSPLIT' {
-            ext.args   = 'build=1 ambiguous2=all maxindel=150000'
+            ext.args   = 'build=1 ambiguous2=all maxindel=150000 ow=f'
             publishDir = [
                 [
                     path: { "${params.outdir}/bbsplit" },

--- a/modules.json
+++ b/modules.json
@@ -6,8 +6,8 @@
             "modules": {
                 "nf-core": {
                     "bbmap/bbsplit": {
-                        "branch": "fix_bbsplit",
-                        "git_sha": "007d8204956159d1d48b81c6403c8e9f5fdbd459",
+                        "branch": "master",
+                        "git_sha": "dcfa9a18a74300f7fb994cdbf518c981f22de73d",
                         "installed_by": ["preprocess_rnaseq"]
                     },
                     "cat/fastq": {

--- a/modules.json
+++ b/modules.json
@@ -6,8 +6,8 @@
             "modules": {
                 "nf-core": {
                     "bbmap/bbsplit": {
-                        "branch": "master",
-                        "git_sha": "e2b2b102d1d2e3b553177ca00ad74dc8a0a42c46",
+                        "branch": "fix_bbsplit",
+                        "git_sha": "007d8204956159d1d48b81c6403c8e9f5fdbd459",
                         "installed_by": ["preprocess_rnaseq"]
                     },
                     "cat/fastq": {

--- a/modules/nf-core/bbmap/bbsplit/main.nf
+++ b/modules/nf-core/bbmap/bbsplit/main.nf
@@ -20,6 +20,7 @@ process BBMAP_BBSPLIT {
     tuple val(meta), path('*primary*fastq.gz'), optional:true, emit: primary_fastq
     tuple val(meta), path('*fastq.gz')        , optional:true, emit: all_fastq
     tuple val(meta), path('*txt')             , optional:true, emit: stats
+    tuple val(meta), path('*.log')            , optional:true, emit: log
     path "versions.yml"                       , emit: versions
 
     when:
@@ -40,27 +41,21 @@ process BBMAP_BBSPLIT {
     other_ref_names.eachWithIndex { name, index ->
         other_refs << "ref_${name}=${other_ref_paths[index]}"
     }
-    if (only_build_index) {
-        if (primary_ref && other_ref_names && other_ref_paths) {
-            """
-            bbsplit.sh \\
-                -Xmx${avail_mem}M \\
-                ref_primary=$primary_ref \\
-                ${other_refs.join(' ')} \\
-                path=bbsplit \\
-                threads=$task.cpus \\
-                $args
 
-            cat <<-END_VERSIONS > versions.yml
-            "${task.process}":
-                bbmap: \$(bbversion.sh | grep -v "Duplicate cpuset")
-            END_VERSIONS
-            """
+    def fastq_in=''
+    def fastq_out=''
+    def index_files=''
+    def refstats_cmd=''
+
+    if (only_build_index) {
+        println("only building index")
+        if (primary_ref && other_ref_names && other_ref_paths) {
+            index_files = 'ref_primary=' +primary_ref + ' ' + other_refs.join(' ') + ' path=bbsplit'
         } else {
             log.error 'ERROR: Please specify as input a primary fasta file along with names and paths to non-primary fasta files.'
         }
     } else {
-        def index_files = ''
+        index_files = ''
         if (index) {
             index_files = "path=$index"
         } else if (primary_ref && other_ref_names && other_ref_paths) {
@@ -68,23 +63,47 @@ process BBMAP_BBSPLIT {
         } else {
             log.error 'ERROR: Please either specify a BBSplit index as input or a primary fasta file along with names and paths to non-primary fasta files.'
         }
-        def fastq_in  = meta.single_end ? "in=${reads}" : "in=${reads[0]} in2=${reads[1]}"
-        def fastq_out = meta.single_end ? "basename=${prefix}_%.fastq.gz" : "basename=${prefix}_%_#.fastq.gz"
-        """
-        bbsplit.sh \\
-            -Xmx${avail_mem}M \\
-            $index_files \\
-            threads=$task.cpus \\
-            $fastq_in \\
-            $fastq_out \\
-            refstats=${prefix}.stats.txt \\
-            $args
-
-        cat <<-END_VERSIONS > versions.yml
-        "${task.process}":
-            bbmap: \$(bbversion.sh | grep -v "Duplicate cpuset")
-        END_VERSIONS
-        """
+        fastq_in  = meta.single_end ? "in=${reads}" : "in=${reads[0]} in2=${reads[1]}"
+        fastq_out = meta.single_end ? "basename=${prefix}_%.fastq.gz" : "basename=${prefix}_%_#.fastq.gz"
+        refstats_cmd = 'refstats=' + prefix + '.stats.txt'
     }
+    """
+
+    # When we stage in the index files the time stamps get disturbed, which
+    # bbsplit doesn't like. Fix the time stamps in its summaries. This needs to
+    # be done via Java to match what bbmap does
+
+    if [ $index ]; then
+        for summary_file in \$(find $index/ref/genome -name summary.txt); do
+            src=\$(grep '^source' "\$summary_file" | cut -f2- -d\$'\\t' | sed 's|.*/bbsplit|bbsplit|')
+            mod=\$(echo "System.out.println(java.nio.file.Files.getLastModifiedTime(java.nio.file.Paths.get(\\"\$src\\")).toMillis());" | jshell -J-Djdk.lang.Process.launchMechanism=vfork -)
+            sed "s|^last modified.*|last modified\\t\$mod|" "\$summary_file" > \${summary_file}.tmp && mv \${summary_file}.tmp \${summary_file}
+        done
+    fi
+
+    # Run BBSplit
+
+    bbsplit.sh \\
+        -Xmx${avail_mem}M \\
+        $index_files \\
+        threads=$task.cpus \\
+        $fastq_in \\
+        $fastq_out \\
+        $refstats_cmd \\
+        $args 2> >(tee ${prefix}.log >&2)
+
+    # Summary files will have an absolute path that will make the index
+    # impossible to use in other processes- we can fix that
+
+    for summary_file in \$(find bbsplit/ref/genome -name summary.txt); do
+        src=\$(grep '^source' "\$summary_file" | cut -f2- -d\$'\\t' | sed 's|.*/bbsplit|bbsplit|')
+        sed "s|^source.*|source\\t\$src|" "\$summary_file" > \${summary_file}.tmp && mv \${summary_file}.tmp \${summary_file}
+    done
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        bbmap: \$(bbversion.sh | grep -v "Duplicate cpuset")
+    END_VERSIONS
+    """
 
 }

--- a/modules/nf-core/bbmap/bbsplit/tests/main.nf.test
+++ b/modules/nf-core/bbmap/bbsplit/tests/main.nf.test
@@ -45,7 +45,7 @@ nextflow_process {
                         [ 'human' ], // meta map
                         file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr22/sequence/chr22_23800000-23980000.fa', checkIfExists: true)
                     ])
-                    input[4] = true
+                    input[4] = false
                     """
                 }
         }
@@ -81,6 +81,7 @@ nextflow_process {
 
             assertAll(
                 { assert process.success },
+                { assert path(process.out.log[0][1]).text.contains("If you wish to regenerate the index") },
                 { assert snapshot(filteredFiles).match("bbsplit_index_filtered_files")},
                 { assert filesExist : "One or more files to exclude do not exist" },
                 { assert snapshot(process.out.versions).match("versions")}


### PR DESCRIPTION
<!--
# nf-core/riboseq pull request

Many thanks for contributing to nf-core/riboseq!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/riboseq/tree/master/.github/CONTRIBUTING.md)
-->

We inherited bbsplit from rnaseq when I copied the processing across, but it wan't working as expected, especially [wrt indices](https://github.com/nf-core/modules/pull/5005). This fixes that.

Note that this is actually not useful for rRNA removal etc (something it took me a second to appreciate)- it's for separating out reads belonging e.g. to a different genome or genomes entirely. But useful to have in the workflow nevertheless.


## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/riboseq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/riboseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
