### PR TITLE
Altos star params

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -541,7 +541,7 @@ if (!params.skip_alignment && params.aligner == 'star_salmon') {
     process {
         withName: 'STAR_ALIGN' {
             ext.args   = { [
-                '--alignEndsType EndToEnd'
+                '--alignEndsType EndToEnd',
                 '--alignIntronMax 500000',
                 '--alignIntronMin 15',
                 '--alignSJoverhangMin 8',

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -541,17 +541,24 @@ if (!params.skip_alignment && params.aligner == 'star_salmon') {
     process {
         withName: 'STAR_ALIGN' {
             ext.args   = { [
-                '--alignSJDBoverhangMin 1',
-                '--alignEndsType EndToEnd',
-                '--outFilterMultimapNmax 20',
-                params.save_unaligned ? '--outReadsUnmapped Fastx' : '',
+                '--alignEndsType EndToEnd'
+                '--alignIntronMax 500000',
+                '--alignIntronMin 15',
+                '--alignSJoverhangMin 8',
+                '--outFilterMatchNminOverLread 0.33',
+                '--outFilterMismatchNmax 2',
+                '--outFilterMultimapNmax 64',
+                '--outFilterScoreMinOverLread 0.33',
+                '--outFilterType BySJout',
+                '--outMultimapperOrder Random',
                 '--outSAMattributes All',
-                '--outSAMstrandField intronMotif',
+                '--outSAMmultNmax -1',
+                params.save_unaligned ? '--outReadsUnmapped Fastx' : '',
                 '--outSAMtype BAM Unsorted',
                 '--quantMode TranscriptomeSAM',
-                '--quantTranscriptomeBan Singleend',
                 '--readFilesCommand zcat',
                 '--runRNGseed 0',
+                '--seedSearchStartLmax 15'
                 '--twopassMode Basic',
                 params.extra_star_align_args ? params.extra_star_align_args.split("\\s(?=--)") : ''
             ].flatten().unique(false).join(' ').trim() }

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -558,7 +558,7 @@ if (!params.skip_alignment && params.aligner == 'star_salmon') {
                 '--quantMode TranscriptomeSAM',
                 '--readFilesCommand zcat',
                 '--runRNGseed 0',
-                '--seedSearchStartLmax 15'
+                '--seedSearchStartLmax 15',
                 '--twopassMode Basic',
                 params.extra_star_align_args ? params.extra_star_align_args.split("\\s(?=--)") : ''
             ].flatten().unique(false).join(' ').trim() }


### PR DESCRIPTION
<!--
# nf-core/riboseq pull request

Many thanks for contributing to nf-core/riboseq!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/riboseq/tree/master/.github/CONTRIBUTING.md)
-->

 For discussion only, illustrating the application of the included STAR parameter changes. Before:

![star_alignment_plot (1)](https://github.com/nf-core/riboseq/assets/5775915/4c0a4482-754f-45d9-80b4-1910f9884646)

After:

![star_alignment_plot](https://github.com/nf-core/riboseq/assets/5775915/da56986e-05dc-4aec-bacd-a5d1bbd0ec0c)

Variable by sample, but there's a pretty consistent reduction in unique mappings with the newer params, so I'm not necessarily convinced.


## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/riboseq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/riboseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
