### PR TITLE
fixes #65 (renamed subworkflow, add missing bai ch)

### DIFF
--- a/workflows/riboseq/main.nf
+++ b/workflows/riboseq/main.nf
@@ -329,7 +329,7 @@ workflow RIBOSEQ {
 
     QUANTIFY_STAR_SALMON (
         ch_samplesheet.map { [ [:], it ] },
-        ch_transcriptome_bam,
+        ch_transcriptome_bam_for_quantification,
         [],
         ch_transcript_fasta,
         ch_gtf,

--- a/workflows/riboseq/main.nf
+++ b/workflows/riboseq/main.nf
@@ -48,7 +48,8 @@ def filterGtf =
 //
 // SUBWORKFLOW: Consisting of a mix of local and nf-core/modules
 //
-include { BAM_DEDUP_STATS_SAMTOOLS_UMITOOLS } from '../../subworkflows/nf-core/bam_dedup_stats_samtools_umitools/main'
+include { BAM_DEDUP_STATS_SAMTOOLS_UMITOOLS as BAM_DEDUP_STATS_SAMTOOLS_UMITOOLS_GENOME} from '../../subworkflows/nf-core/bam_dedup_stats_samtools_umitools/main'
+include { BAM_DEDUP_STATS_SAMTOOLS_UMITOOLS as BAM_DEDUP_STATS_SAMTOOLS_UMITOOLS_TRANSCRIPTOME} from '../../subworkflows/nf-core/bam_dedup_stats_samtools_umitools/main'
 include { PREPROCESS_RNASEQ                 } from '../../subworkflows/nf-core/preprocess_rnaseq'
 include { FASTQ_ALIGN_STAR                  } from '../../subworkflows/nf-core/fastq_align_star'
 
@@ -179,7 +180,8 @@ workflow RIBOSEQ {
 
     ch_genome_bam              = FASTQ_ALIGN_STAR.out.bam
     ch_genome_bam_index        = FASTQ_ALIGN_STAR.out.bai
-    ch_transcriptome_bam       = FASTQ_ALIGN_STAR.out.orig_bam_transcript
+    ch_transcriptome_bam       = FASTQ_ALIGN_STAR.out.bam_transcript
+    ch_transcriptome_bai       = FASTQ_ALIGN_STAR.out.bai_transcript
     ch_versions                = ch_versions.mix(FASTQ_ALIGN_STAR.out.versions)
 
     ch_multiqc_files = ch_multiqc_files

--- a/workflows/riboseq/main.nf
+++ b/workflows/riboseq/main.nf
@@ -180,7 +180,7 @@ workflow RIBOSEQ {
 
     ch_genome_bam              = FASTQ_ALIGN_STAR.out.bam
     ch_genome_bam_index        = FASTQ_ALIGN_STAR.out.bai
-    ch_transcriptome_bam       = FASTQ_ALIGN_STAR.out.bam_transcript
+    ch_transcriptome_bam       = FASTQ_ALIGN_STAR.out.orig_bam_transcript
     ch_transcriptome_bai       = FASTQ_ALIGN_STAR.out.bai_transcript
     ch_versions                = ch_versions.mix(FASTQ_ALIGN_STAR.out.versions)
 
@@ -224,7 +224,7 @@ workflow RIBOSEQ {
             .mix(BAM_DEDUP_STATS_SAMTOOLS_UMITOOLS_TRANSCRIPTOME.out.idxstats.collect{it[1]})
 
         // Prepare trancriptome BAM for Salmon. This requires a Samtools name
-        // sort and a specific umittools command
+        // sort and a specific umitools command
 
         SAMTOOLS_SORT (
             BAM_DEDUP_STATS_SAMTOOLS_UMITOOLS_TRANSCRIPTOME.out.bam,
@@ -325,6 +325,8 @@ workflow RIBOSEQ {
     //
     // SUBWORKFLOW: Count reads from BAM alignments using Salmon
     //
+    ch_transcriptome_bam_for_quantification = params.with_umi ? ch_transcriptome_bam_for_salmon : ch_transcriptome_bam
+
     QUANTIFY_STAR_SALMON (
         ch_samplesheet.map { [ [:], it ] },
         ch_transcriptome_bam,


### PR DESCRIPTION
<!--
# nf-core/riboseq pull request

Many thanks for contributing to nf-core/riboseq!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/riboseq/tree/master/.github/CONTRIBUTING.md)
-->

Fixes #65 by:
- including and renaming the `BAM_DEDUP_STATS_SAMTOOLS_UMITOOLS` for genome and transcriptome
- defining `ch_transcriptome_bai` (not sure using this one is correct given original transcript bam used in `    ch_transcriptome_bam       = FASTQ_ALIGN_STAR.out.orig_bam_transcript`
- adding `--with_umi` param logic to ensure umi_tools prepare-for-rsem deduplicated reads are quantified with Salmon


## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/riboseq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/riboseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nf-test test main.nf.test -profile test,docker`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
