### PR TITLE
Remove conda from CI

### DIFF
--- a/.github/workflows/nf-test.yml
+++ b/.github/workflows/nf-test.yml
@@ -68,13 +68,11 @@ jobs:
       fail-fast: false
       matrix:
         shard: ${{ fromJson(needs.nf-test-changes.outputs.shard) }}
-        profile: [conda, docker, singularity]
+        profile: [docker, singularity]
         isMain:
           - ${{ github.base_ref == 'master' || github.base_ref == 'main' }}
-        # Exclude conda and singularity on dev
+        # Exclude singularity on dev
         exclude:
-          - isMain: false
-            profile: "conda"
           - isMain: false
             profile: "singularity"
         NXF_VER:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#111](https://github.com/nf-core/riboseq/pull/111) - Template update for nf-core/tools v3.4.1 ([@nf-corebot](https://github.com/nf-corebot), [@maxulysse](https://github.com/maxulysse), reviewed by [@mashehu](https://github.com/mashehu))
 - [#115](https://github.com/nf-core/riboseq/pull/115) - Prerelease changes v1.2.0 ([@iraiosub](https://github.com/pinin4fjords), review by [@JackCurragh](https://github.com/JackCurragh))
 - [#117](https://github.com/nf-core/riboseq/pull/117) - Update modules for v1.2.0: `fq/lint`, `fq/subsample` and `sortmerna`([@iraiosub](https://github.com/pinin4fjords), review by [@JackCurragh](https://github.com/JackCurragh))
+- [#120](https://github.com/nf-core/riboseq/pull/120) - Bump Nextflow minimum version to 25.04.8
+- [#121](https://github.com/nf-core/riboseq/pull/121) - Remove conda from CI due to upstream ribotish Python 3.14 incompatibility
 
 ### `Fixed`
 


### PR DESCRIPTION
## Summary

Disabling conda in CI due to upstream ribotish incompatibility with Python 3.14.

## Problem

The conda CI test fails with:
```
NameError: name 'genomefapath' is not defined
```

This occurs in `ribotish/run/predict.py` line 364 when running with Python 3.14, which is now the default Python version installed by conda.

## Root Cause

The ribotish tool has a bug that is exposed by Python 3.14's stricter handling. This is an **upstream issue** in ribotish, not a pipeline bug.

## Solution

Remove conda from CI profiles, matching the approach taken in:
- #99 (previous conda removal for v1.1.0 release)
- nf-core/rnaseq (conda already disabled)

Docker and Singularity tests continue to pass as they use containers with pinned Python versions.

## Test Plan

- [x] Docker tests pass
- [x] Singularity tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)