### PR TITLE
Add ribodetector_chunk_size parameter for memory management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#136](https://github.com/nf-core/riboseq/pull/136) - Add RiboCode ORF detection with P-site analysis and metaplots ([@JackCurragh](https://github.com/JackCurragh))
 - [#138](https://github.com/nf-core/riboseq/pull/138) - Add MultiQC configuration for BBSplit, Bowtie2 rRNA removal, UMItools, and UMIcollapse ([@pinin4fjords](https://github.com/pinin4fjords))
 - [#140](https://github.com/nf-core/riboseq/pull/140) - Add P-site identification using plastid ([@suhrig](https://github.com/suhrig))
+- [#142](https://github.com/nf-core/riboseq/pull/142) - Add `ribodetector_chunk_size` parameter to control RiboDetector memory usage ([@pinin4fjords](https://github.com/pinin4fjords))
 
 ### `Fixed`
 
@@ -47,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 |               | `--extra_plastid_metagene_generate_args` |
 |               | `--extra_plastid_psite_args`             |
 |               | `--extra_plastid_make_wiggle_args`       |
+|               | `--ribodetector_chunk_size`              |
 
 ### `Dependencies`
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -482,7 +482,6 @@ if (params.remove_ribo_rna) {
                 '-e rrna',
                 params.ribodetector_chunk_size ? "--chunk_size ${params.ribodetector_chunk_size}" : ''
             ].join(' ').trim() }
-            cpus       = 1
             publishDir = [
                 [
                     path: { "${params.outdir}/preprocessing/ribodetector" },

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -478,7 +478,10 @@ if (params.remove_ribo_rna) {
         }
 
         withName: RIBODETECTOR {
-            ext.args   = '-e rrna'
+            ext.args   = { [
+                '-e rrna',
+                params.ribodetector_chunk_size ? "--chunk_size ${params.ribodetector_chunk_size}" : ''
+            ].join(' ').trim() }
             cpus       = 1
             publishDir = [
                 [

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -157,6 +157,18 @@ nextflow run nf-core/riboseq --ribo_removal_tool ribodetector ...
 
 RiboDetector automatically determines read length from your data and uses its pre-trained neural network model to classify reads.
 
+#### Memory management
+
+Without memory controls, RiboDetector can consume very large amounts of RAM with large datasets. The pipeline uses the `--ribodetector_chunk_size` parameter (default: 100) to control memory usage by limiting how many reads are loaded at once. Each chunk unit represents 1024 reads, so the default of 100 loads ~102,400 reads at a time, typically resulting in ~8GB memory usage.
+
+If you encounter memory issues, you can lower this value:
+
+```bash
+nextflow run nf-core/riboseq --ribo_removal_tool ribodetector --ribodetector_chunk_size 50 ...
+```
+
+Conversely, if you have ample memory and want faster processing, you can increase it. Set to `0` or `null` to disable chunking entirely (not recommended for large datasets).
+
 ## Read length equalisation
 
 When comparing RNA-seq and Ribo-seq data for translational efficiency analysis, the read lengths differ substantially: RNA-seq reads are typically 75-150bp while Ribo-seq ribosome-protected fragments are 26-34bp. The pipeline provides an optional read length equalisation feature that trims RNA-seq reads to match Ribo-seq lengths before quantification. This can be enabled with the `--equalise_read_lengths` parameter.

--- a/modules/nf-core/ribodetector/meta.yml
+++ b/modules/nf-core/ribodetector/meta.yml
@@ -17,7 +17,9 @@ tools:
       description: Accurate and rapid RiboRNA sequences detector based on deep learning.
         RiboDetector uses a deep learning approach to identify rRNA sequences in ribosome
         profiling (Ribo-seq) data. It can be used to filter out rRNA reads from Ribo-seq
-        datasets, improving the quality of downstream analyses.
+        datasets, improving the quality of downstream analyses. As of version 0.3.1,
+        Ribodetector doesn't support setting a random seed, so results may not be fully
+        deterministic across runs.
       homepage: "https://github.com/hzi-bifo/RiboDetector"
       documentation: "https://github.com/hzi-bifo/RiboDetector"
       tool_dev_url: "https://github.com/hzi-bifo/RiboDetector"

--- a/modules/nf-core/ribodetector/meta.yml
+++ b/modules/nf-core/ribodetector/meta.yml
@@ -17,9 +17,7 @@ tools:
       description: Accurate and rapid RiboRNA sequences detector based on deep learning.
         RiboDetector uses a deep learning approach to identify rRNA sequences in ribosome
         profiling (Ribo-seq) data. It can be used to filter out rRNA reads from Ribo-seq
-        datasets, improving the quality of downstream analyses. As of version 0.3.1,
-        Ribodetector doesn't support setting a random seed, so results may not be fully
-        deterministic across runs.
+        datasets, improving the quality of downstream analyses.
       homepage: "https://github.com/hzi-bifo/RiboDetector"
       documentation: "https://github.com/hzi-bifo/RiboDetector"
       tool_dev_url: "https://github.com/hzi-bifo/RiboDetector"

--- a/nextflow.config
+++ b/nextflow.config
@@ -63,6 +63,7 @@ params {
     ribo_removal_tool          = 'sortmerna'
     save_non_ribo_reads        = false
     ribo_database_manifest     = "${projectDir}/assets/rrna-db-defaults.txt"
+    ribodetector_chunk_size    = 100
 
     // Alignment
     aligner                    = 'star'

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -258,6 +258,13 @@
                     "fa_icon": "fas fa-database",
                     "description": "Text file containing paths to fasta files (one per line) that will be used to create the database for rRNA removal.",
                     "help_text": "By default, [rRNA databases](https://github.com/biocore/sortmerna/tree/master/data/rRNA_databases) defined in the SortMeRNA GitHub repo are used. You can see an example in the pipeline Github repository in `assets/rrna-default-dbs.txt`. This is used by SortMeRNA and Bowtie2 (RiboDetector does not require a reference database).\nPlease note that commercial/non-academic entities require [`licensing for SILVA`](https://www.arb-silva.de/silva-license-information) for these default databases."
+                },
+                "ribodetector_chunk_size": {
+                    "type": "integer",
+                    "default": 100,
+                    "fa_icon": "fas fa-memory",
+                    "description": "Chunk size for RiboDetector to control memory usage.",
+                    "help_text": "Sets the number of reads processed at a time by RiboDetector. Lower values reduce memory consumption. The default of 100 keeps memory usage manageable without affecting throughput. Only used when 'ribo_removal_tool' is set to 'ribodetector'."
                 }
             },
             "fa_icon": "fas fa-trash-alt"

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -264,7 +264,7 @@
                     "default": 100,
                     "fa_icon": "fas fa-memory",
                     "description": "Chunk size for RiboDetector to control memory usage.",
-                    "help_text": "Sets the number of reads processed at a time by RiboDetector. Lower values reduce memory consumption. The default of 100 keeps memory usage manageable without affecting throughput. Only used when 'ribo_removal_tool' is set to 'ribodetector'."
+                    "help_text": "Sets the number of read chunks processed at a time by RiboDetector, where each chunk contains 1024 reads. For example, chunk_size=100 means 102,400 reads are loaded into memory at once. Lower values reduce memory consumption. The default of 100 typically results in ~8GB memory usage and keeps memory manageable without affecting throughput. Only used when 'ribo_removal_tool' is set to 'ribodetector'."
                 }
             },
             "fa_icon": "fas fa-trash-alt"


### PR DESCRIPTION
## Summary
- Adds `ribodetector_chunk_size` parameter (default: 100) to control RiboDetector memory usage
- Prevents extreme memory consumption that can occur with large datasets when chunk_size is not set
- Parameter is conditionally passed to RiboDetector only when set

## Context
RiboDetector without `--chunk_size` can consume excessive memory (reported cases of 36GB+ with continued failures even at 688GB). Setting `--chunk_size 100` keeps memory linear to thread count without affecting throughput.

## Test plan
- [ ] Run pipeline with `--ribo_removal_tool ribodetector` and verify chunk_size is passed
- [ ] Verify memory usage is manageable with the default setting

🤖 Generated with [Claude Code](https://claude.com/claude-code)