### PR TITLE
Coverage tracks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#136](https://github.com/nf-core/riboseq/pull/136) - Add RiboCode ORF detection with P-site analysis and metaplots ([@JackCurragh](https://github.com/JackCurragh))
 - [#138](https://github.com/nf-core/riboseq/pull/138) - Add MultiQC configuration for BBSplit, Bowtie2 rRNA removal, UMItools, and UMIcollapse ([@pinin4fjords](https://github.com/pinin4fjords))
 - [#140](https://github.com/nf-core/riboseq/pull/140) - Add P-site identification using plastid ([@suhrig](https://github.com/suhrig))
+- [#144](https://github.com/nf-core/riboseq/pull/142) - Add bigWig coverage tracks ([@suhrig](https://github.com/suhrig))
 
 ### `Fixed`
 
@@ -47,13 +48,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 |               | `--extra_plastid_metagene_generate_args` |
 |               | `--extra_plastid_psite_args`             |
 |               | `--extra_plastid_make_wiggle_args`       |
+|               | `--skip_coverage_tracks`                 |
 
 ### `Dependencies`
 
-| Dependency | Old version | New version |
-| ---------- | ----------- | ----------- |
-| `MultiQC`  | 1.32        | 1.33        |
-| `plastid`  |             | 0.6.1       |
+| Dependency         | Old version | New version |
+| ------------------ | ----------- | ----------- |
+| `MultiQC`          | 1.32        | 1.33        |
+| `plastid`          |             | 0.6.1       |
+| `bedtools`         |             | 2.31.1      |
+| `bedGraphToBigWig` |             | 469         |
 
 ## v1.2.0 - 2025-12-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#138](https://github.com/nf-core/riboseq/pull/138) - Add MultiQC configuration for BBSplit, Bowtie2 rRNA removal, UMItools, and UMIcollapse ([@pinin4fjords](https://github.com/pinin4fjords))
 - [#140](https://github.com/nf-core/riboseq/pull/140) - Add P-site identification using plastid ([@suhrig](https://github.com/suhrig))
 - [#142](https://github.com/nf-core/riboseq/pull/142) - Add `ribodetector_chunk_size` parameter to control RiboDetector memory usage ([@pinin4fjords](https://github.com/pinin4fjords))
-- [#144](https://github.com/nf-core/riboseq/pull/142) - Add bigWig coverage tracks ([@suhrig](https://github.com/suhrig))
+- [#144](https://github.com/nf-core/riboseq/pull/144) - Add bigWig coverage tracks ([@suhrig](https://github.com/suhrig))
 
 ### `Fixed`
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ nf-core/riboseq was originally written by [Jonathan Manning](https://github.com/
 - [Jack Tierney](https://github.com/JackCurragh) (University College Cork)
 - [Maxime U Garcia](https://github.com/maxulysse) (Seqera)
 - [Ira A Iosub](https://github.com/iraiosub) (The Francis Crick Institute)
+- [Sebastian Uhrig](https://github.com/suhrig) (Freelance bioinformatician)
 
 ## Contributions and Support
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -910,7 +910,7 @@ if (!params.skip_coverage_tracks) {
             ext.prefix = { "${meta.id}.${meta.strand}" }
             publishDir = [ enabled: false ]
         }
-    
+
         withName: 'UCSC_BEDGRAPHTOBIGWIG' {
             ext.prefix = { "${meta.id}.${meta.strand}" }
             publishDir = [

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -914,7 +914,7 @@ process {
             enabled: false
         ]
     }
-    
+
     withName: 'UCSC_BEDGRAPHTOBIGWIG' {
         ext.prefix = { "${meta.id}.${meta.strand}" }
         publishDir = [

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -900,14 +900,13 @@ if (!params.skip_alignment && params.aligner == 'star') {
 if (!params.skip_coverage_tracks) {
     process {
         withName: SAMTOOLS_VIEW_SPLIT_BY_STRAND {
-            // Filter expression to extract reads by strand, taking into consideration the strandedness of the library and paired-end mates
-            ext.args = { "-e '(\"${meta.strandedness}\" == \"forward\") == (((flag.read1 || !flag.paired) && (!flag.reverse == (\"${meta.strand}\" == \"forward\"))) || (flag.read2 && ((!flag.mreverse == (\"${meta.strand}\" == \"forward\")) != (!flag.reverse == !flag.mreverse))))'" }
+            ext.args   = { meta.strand_filter }
             ext.prefix = { "${meta.id}.${meta.strand}" }
             publishDir = [ enabled: false ]
         }
 
         withName: 'BEDTOOLS_GENOMECOV' {
-            ext.args = "-bg -split"
+            ext.args   = "-bg -split"
             ext.prefix = { "${meta.id}.${meta.strand}" }
             publishDir = [ enabled: false ]
         }

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -891,6 +891,37 @@ if (!params.skip_alignment && params.aligner == 'star') {
     }
 }
 
+//
+// Coverage track generation
+//
+
+process {
+    withName: SAMTOOLS_VIEW_SPLIT_BY_STRAND {
+        // Filter expression to extract reads by strand, taking into consideration the strandedness of the library and paired-end mates
+        ext.args = { "-e '(\"${meta.strandedness}\" == \"forward\") == (((flag.read1 || !flag.paired) && (!flag.reverse == (\"${meta.strand}\" == \"forward\"))) || (flag.read2 && ((!flag.mreverse == (\"${meta.strand}\" == \"forward\")) != (!flag.reverse == !flag.mreverse))))'" }
+        ext.prefix = { "${meta.id}.${meta.strand}" }
+        publishDir = [
+            enabled: false
+        ]
+    }
+
+    withName: 'BEDTOOLS_GENOMECOV' {
+        ext.args = "-bg -split"
+        ext.prefix = { "${meta.id}.${meta.strand}" }
+        publishDir = [
+            enabled: false
+        ]
+    }
+    
+    withName: 'UCSC_BEDGRAPHTOBIGWIG' {
+        ext.prefix = { "${meta.id}.${meta.strand}" }
+        publishDir = [
+            path: { "${params.outdir}/coverage" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+}
 
 if (!params.skip_multiqc) {
     process {

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -897,31 +897,29 @@ if (!params.skip_alignment && params.aligner == 'star') {
 // Coverage track generation
 //
 
-process {
-    withName: SAMTOOLS_VIEW_SPLIT_BY_STRAND {
-        // Filter expression to extract reads by strand, taking into consideration the strandedness of the library and paired-end mates
-        ext.args = { "-e '(\"${meta.strandedness}\" == \"forward\") == (((flag.read1 || !flag.paired) && (!flag.reverse == (\"${meta.strand}\" == \"forward\"))) || (flag.read2 && ((!flag.mreverse == (\"${meta.strand}\" == \"forward\")) != (!flag.reverse == !flag.mreverse))))'" }
-        ext.prefix = { "${meta.id}.${meta.strand}" }
-        publishDir = [
-            enabled: false
-        ]
-    }
+if (!params.skip_coverage_tracks) {
+    process {
+        withName: SAMTOOLS_VIEW_SPLIT_BY_STRAND {
+            // Filter expression to extract reads by strand, taking into consideration the strandedness of the library and paired-end mates
+            ext.args = { "-e '(\"${meta.strandedness}\" == \"forward\") == (((flag.read1 || !flag.paired) && (!flag.reverse == (\"${meta.strand}\" == \"forward\"))) || (flag.read2 && ((!flag.mreverse == (\"${meta.strand}\" == \"forward\")) != (!flag.reverse == !flag.mreverse))))'" }
+            ext.prefix = { "${meta.id}.${meta.strand}" }
+            publishDir = [ enabled: false ]
+        }
 
-    withName: 'BEDTOOLS_GENOMECOV' {
-        ext.args = "-bg -split"
-        ext.prefix = { "${meta.id}.${meta.strand}" }
-        publishDir = [
-            enabled: false
-        ]
-    }
-
-    withName: 'UCSC_BEDGRAPHTOBIGWIG' {
-        ext.prefix = { "${meta.id}.${meta.strand}" }
-        publishDir = [
-            path: { "${params.outdir}/coverage" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
-        ]
+        withName: 'BEDTOOLS_GENOMECOV' {
+            ext.args = "-bg -split"
+            ext.prefix = { "${meta.id}.${meta.strand}" }
+            publishDir = [ enabled: false ]
+        }
+    
+        withName: 'UCSC_BEDGRAPHTOBIGWIG' {
+            ext.prefix = { "${meta.id}.${meta.strand}" }
+            publishDir = [
+                path: { "${params.outdir}/coverage" },
+                mode: params.publish_dir_mode,
+                saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+            ]
+        }
     }
 }
 

--- a/docs/output.md
+++ b/docs/output.md
@@ -28,6 +28,7 @@ The pipeline is built using [Nextflow](https://www.nextflow.io/) and processes d
   - [Alignment](#alignment)
     - [STAR](#star)
   - [UMI-tools deduplication](#umi-tools-deduplication)
+  - [Coverage tracks](#coverage-tracks)
   - [Riboseq-specific QC](#riboseq-specific-qc)
     - [Ribo-TISH quality](#ribo-tish-quality)
     - [Ribotricer detect-orfs QC outputs](#ribotricer-detect-orfs-qc-outputs)
@@ -282,6 +283,15 @@ The content of the files above is explained in more detail in the [UMI-tools doc
 </details>
 
 After extracting the UMI information from the read sequence (see [UMI-tools extract](#umi-tools-extract)), the second step in the removal of UMI barcodes involves deduplicating the reads based on both mapping and UMI barcode information. UMI deduplication can be carried out either with [UMI-tools](https://github.com/CGATOxford/UMI-tools) or [UMICollapse](https://github.com/Daniel-Liu-c0deb0t/UMICollapse), set via the `umi_dedup_tool` parameter. The output BAM files are the same, though UMI-tools has some additional outputs, as described above. Either method will generate a filtered BAM file after the removal of PCR duplicates.
+
+## Coverage tracks
+
+The pipeline produces coverage tracks in bigWig format. In the case of stranded libraries, two tracks are created per sample - one for the coverage of the forward strand and one for the reverse strand. In the case of unstranded libraries, only one track is created.
+
+- `coverage`
+  - `<SAMPLE>.forward.bigWig`: Coverage on the forward strand (only created for stranded libraries)
+  - `<SAMPLE>.reverse.bigWig`: Coverage on the reverse strand (only created for stranded libraries)
+  - `<SAMPLE>.unstranded.bigWig`: Sum of coverage of forward and reverse strand (only created for unstranded libraries)
 
 ## Riboseq-specific QC
 

--- a/docs/output.md
+++ b/docs/output.md
@@ -20,7 +20,7 @@ The pipeline is built using [Nextflow](https://www.nextflow.io/) and processes d
   - [Preprocessing](#preprocessing)
     - [cat](#cat)
     - [FastQC](#fastqc)
-    - [UMI-tools extract](#umi-tools-extract)
+    - [UMI-tools extract](#umi-dedup)
     - [TrimGalore](#trimgalore)
     - [fastp](#fastp)
     - [BBSplit](#bbsplit)

--- a/modules.json
+++ b/modules.json
@@ -15,6 +15,11 @@
                         "git_sha": "6da7216c83d9d885bdeb7aef1bcb9b51a90f370b",
                         "installed_by": ["fastq_qc_trim_filter_setstrandedness"]
                     },
+                    "bedtools/genomecov": {
+                        "branch": "master",
+                        "git_sha": "e753770db613ce014b3c4bc94f6cba443427b726",
+                        "installed_by": ["modules"]
+                    },
                     "bowtie2/align": {
                         "branch": "master",
                         "git_sha": "e753770db613ce014b3c4bc94f6cba443427b726",
@@ -253,6 +258,11 @@
                         "branch": "master",
                         "git_sha": "e753770db613ce014b3c4bc94f6cba443427b726",
                         "installed_by": ["quantify_pseudo_alignment"]
+                    },
+                    "ucsc/bedgraphtobigwig": {
+                        "branch": "master",
+                        "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
+                        "installed_by": ["modules"]
                     },
                     "umicollapse": {
                         "branch": "master",

--- a/modules/nf-core/bedtools/genomecov/environment.yml
+++ b/modules/nf-core/bedtools/genomecov/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bioconda::bedtools=2.31.1

--- a/modules/nf-core/bedtools/genomecov/main.nf
+++ b/modules/nf-core/bedtools/genomecov/main.nf
@@ -1,0 +1,77 @@
+process BEDTOOLS_GENOMECOV {
+    tag "$meta.id"
+    label 'process_single'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/63/6397750e9730a3fbcc5b4c43f14bd141c64c723fd7dad80e47921a68a7c3cd21/data':
+        'community.wave.seqera.io/library/bedtools_coreutils:a623c13f66d5262b' }"
+
+    input:
+    tuple val(meta), path(intervals), val(scale)
+    path  sizes
+    val   extension
+    val   sort
+
+    output:
+    tuple val(meta), path("*.${extension}"), emit: genomecov
+    path  "versions.yml"                   , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args      = task.ext.args  ?: ''
+    def args_list = args.tokenize()
+    args += (scale > 0 && scale != 1) ? " -scale $scale" : ""
+    if (!args_list.contains('-bg') && (scale > 0 && scale != 1)) {
+        args += " -bg"
+    }
+    // Sorts output file by chromosome and position using additional options for performance and consistency
+    // See https://www.biostars.org/p/66927/ for further details
+    def buffer   = task.memory ? "--buffer-size=${task.memory.toGiga().intdiv(2)}G" : ''
+    def sort_cmd = sort ? "| LC_ALL=C sort --parallel=$task.cpus $buffer -k1,1 -k2,2n" : ''
+
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    if (intervals.name =~ /\.bam/) {
+        """
+        bedtools \\
+            genomecov \\
+            -ibam $intervals \\
+            $args \\
+            $sort_cmd \\
+            > ${prefix}.${extension}
+
+        cat <<-END_VERSIONS > versions.yml
+        "${task.process}":
+            bedtools: \$(bedtools --version | sed -e "s/bedtools v//g")
+        END_VERSIONS
+        """
+    } else {
+        """
+        bedtools \\
+            genomecov \\
+            -i $intervals \\
+            -g $sizes \\
+            $args \\
+            $sort_cmd \\
+            > ${prefix}.${extension}
+
+        cat <<-END_VERSIONS > versions.yml
+        "${task.process}":
+            bedtools: \$(bedtools --version | sed -e "s/bedtools v//g")
+        END_VERSIONS
+        """
+    }
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch  ${prefix}.${extension}
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        bedtools: \$(bedtools --version | sed -e "s/bedtools v//g")
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/bedtools/genomecov/meta.yml
+++ b/modules/nf-core/bedtools/genomecov/meta.yml
@@ -1,0 +1,76 @@
+name: bedtools_genomecov
+description: Computes histograms (default), per-base reports (-d) and BEDGRAPH (-bg)
+  summaries of feature coverage (e.g., aligned sequences) for a given genome.
+keywords:
+  - bed
+  - bam
+  - genomecov
+  - bedtools
+  - histogram
+tools:
+  - bedtools:
+      description: |
+        A set of tools for genomic analysis tasks, specifically enabling genome arithmetic (merge, count, complement) on various file types.
+      documentation: https://bedtools.readthedocs.io/en/latest/content/tools/genomecov.html
+      licence: ["MIT"]
+      identifier: biotools:bedtools
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:false ]
+    - intervals:
+        type: file
+        description: BAM/BED/GFF/VCF
+        pattern: "*.{bam|bed|gff|vcf}"
+        ontologies: []
+    - scale:
+        type: integer
+        description: Number containing the scale factor for the output. Set to 1 to
+          disable. Setting to a value other than 1 will also get the -bg bedgraph output
+          format as this is required for this command switch
+  - sizes:
+      type: file
+      description: Tab-delimited table of chromosome names in the first column and chromosome
+        sizes in the second column
+      ontologies: []
+  - extension:
+      type: string
+      description: Extension of the output file (e. g., ".bg", ".bedgraph", ".txt",
+        ".tab", etc.) It is set arbitrarily by the user and corresponds to the file
+        format which depends on arguments.
+  - sort:
+      type: boolean
+      description: Sort the output
+output:
+  genomecov:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.${extension}":
+          type: file
+          description: Computed genome coverage file
+          pattern: "*.${extension}"
+          ontologies: []
+  versions:
+    - versions.yml:
+        type: file
+        description: File containing software versions
+        pattern: "versions.yml"
+        ontologies:
+          - edam: http://edamontology.org/format_3750 # YAML
+authors:
+  - "@edmundmiller"
+  - "@sruthipsuresh"
+  - "@drpatelh"
+  - "@sidorov-si"
+  - "@chris-cheshire"
+maintainers:
+  - "@edmundmiller"
+  - "@sruthipsuresh"
+  - "@drpatelh"
+  - "@sidorov-si"
+  - "@chris-cheshire"

--- a/modules/nf-core/bedtools/genomecov/tests/main.nf.test
+++ b/modules/nf-core/bedtools/genomecov/tests/main.nf.test
@@ -1,0 +1,174 @@
+nextflow_process {
+    name "Test Process BEDTOOLS_GENOMECOV"
+    script "../main.nf"
+    process "BEDTOOLS_GENOMECOV"
+    config "./nextflow.config"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "bedtools"
+    tag "bedtools/genomecov"
+
+    test("sarscov2 - no scale") {
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    file(params.modules_testdata_base_path + "genomics/sarscov2/illumina/bam/test.paired_end.bam", checkIfExists: true),
+                    1
+                ]
+                // sizes
+                input[1] = []
+                // extension
+                input[2] = "txt"
+                input[3] = true
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("sarscov2 - dummy sizes") {
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test'],
+                    file(params.modules_testdata_base_path + "genomics/sarscov2/illumina/bam/test.paired_end.bam", checkIfExists: true),
+                    0.5
+                ]
+                // sizes
+                input[1] = file('dummy_chromosome_sizes')
+                // extension
+                input[2] = 'txt'
+                input[3] = false
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("sarscov2 - scale") {
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test'],
+                    file(params.modules_testdata_base_path + "genomics/sarscov2/genome/bed/baits.bed", checkIfExists: true),
+                    0.5
+                ]
+                // sizes
+                input[1] = file(params.modules_testdata_base_path + "genomics/sarscov2/genome/genome.sizes", checkIfExists: true)
+                // extension
+                input[2] = 'txt'
+                input[3] = false
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("sarscov2 - no scale - stub") {
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    file(params.modules_testdata_base_path + "genomics/sarscov2/illumina/bam/test.paired_end.bam", checkIfExists: true),
+                    1
+                ]
+                // sizes
+                input[1] = []
+                // extension
+                input[2] = "txt"
+                input[3] = true
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("sarscov2 - dummy sizes - stub") {
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test'],
+                    file(params.modules_testdata_base_path + "genomics/sarscov2/illumina/bam/test.paired_end.bam", checkIfExists: true),
+                    0.5
+                ]
+                // sizes
+                input[1] = file('dummy_chromosome_sizes')
+                // extension
+                input[2] = 'txt'
+                input[3] = false
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("sarscov2 - scale - stub") {
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test'],
+                    file(params.modules_testdata_base_path + "genomics/sarscov2/genome/bed/baits.bed", checkIfExists: true),
+                    0.5
+                ]
+                // sizes
+                input[1] = file(params.modules_testdata_base_path + "genomics/sarscov2/genome/genome.sizes", checkIfExists: true)
+                // extension
+                input[2] = 'txt'
+                input[3] = false
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+}

--- a/modules/nf-core/bedtools/genomecov/tests/main.nf.test.snap
+++ b/modules/nf-core/bedtools/genomecov/tests/main.nf.test.snap
@@ -1,0 +1,200 @@
+{
+    "sarscov2 - dummy sizes": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.coverage.txt:md5,01291b6e1beab72e046653e709eb0e10"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,5fd44452613992a6f71f2c73d2e117f2"
+                ],
+                "genomecov": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.coverage.txt:md5,01291b6e1beab72e046653e709eb0e10"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,5fd44452613992a6f71f2c73d2e117f2"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.2"
+        },
+        "timestamp": "2024-07-05T11:59:33.898146"
+    },
+    "sarscov2 - no scale - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.coverage.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,5fd44452613992a6f71f2c73d2e117f2"
+                ],
+                "genomecov": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.coverage.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,5fd44452613992a6f71f2c73d2e117f2"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.2"
+        },
+        "timestamp": "2024-07-05T11:59:52.483371"
+    },
+    "sarscov2 - scale": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.coverage.txt:md5,de3c59c0ea123bcdbbad27bc0a0a601e"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,5fd44452613992a6f71f2c73d2e117f2"
+                ],
+                "genomecov": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.coverage.txt:md5,de3c59c0ea123bcdbbad27bc0a0a601e"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,5fd44452613992a6f71f2c73d2e117f2"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.2"
+        },
+        "timestamp": "2024-07-05T11:59:43.69501"
+    },
+    "sarscov2 - scale - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.coverage.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,5fd44452613992a6f71f2c73d2e117f2"
+                ],
+                "genomecov": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.coverage.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,5fd44452613992a6f71f2c73d2e117f2"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.2"
+        },
+        "timestamp": "2024-07-05T12:00:09.930036"
+    },
+    "sarscov2 - no scale": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.coverage.txt:md5,66083198daca6c001d328ba9616e9b53"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,5fd44452613992a6f71f2c73d2e117f2"
+                ],
+                "genomecov": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.coverage.txt:md5,66083198daca6c001d328ba9616e9b53"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,5fd44452613992a6f71f2c73d2e117f2"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.2"
+        },
+        "timestamp": "2024-07-05T11:59:25.448817"
+    },
+    "sarscov2 - dummy sizes - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.coverage.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,5fd44452613992a6f71f2c73d2e117f2"
+                ],
+                "genomecov": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.coverage.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,5fd44452613992a6f71f2c73d2e117f2"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.2"
+        },
+        "timestamp": "2024-07-05T12:00:01.086433"
+    }
+}

--- a/modules/nf-core/bedtools/genomecov/tests/nextflow.config
+++ b/modules/nf-core/bedtools/genomecov/tests/nextflow.config
@@ -1,0 +1,7 @@
+process {
+
+    withName: BEDTOOLS_GENOMECOV {
+        ext.prefix = { "${meta.id}.coverage" }
+    }
+
+}

--- a/modules/nf-core/ucsc/bedgraphtobigwig/environment.yml
+++ b/modules/nf-core/ucsc/bedgraphtobigwig/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bioconda::ucsc-bedgraphtobigwig=469

--- a/modules/nf-core/ucsc/bedgraphtobigwig/main.nf
+++ b/modules/nf-core/ucsc/bedgraphtobigwig/main.nf
@@ -1,0 +1,49 @@
+process UCSC_BEDGRAPHTOBIGWIG {
+    tag "$meta.id"
+    label 'process_single'
+
+    // WARN: Version information not provided by tool on CLI. Please update version string below when bumping container versions.
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/ucsc-bedgraphtobigwig:469--h9b8f530_0' :
+        'biocontainers/ucsc-bedgraphtobigwig:469--h9b8f530_0' }"
+
+    input:
+    tuple val(meta), path(bedgraph)
+    path  sizes
+
+    output:
+    tuple val(meta), path("*.bigWig"), emit: bigwig
+    path "versions.yml"              , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def VERSION = '469' // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.
+    """
+    bedGraphToBigWig \\
+        $bedgraph \\
+        $sizes \\
+        ${prefix}.bigWig
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        ucsc: $VERSION
+    END_VERSIONS
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def VERSION = '469' // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.
+    """
+    touch ${prefix}.bigWig
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        ucsc: $VERSION
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/ucsc/bedgraphtobigwig/meta.yml
+++ b/modules/nf-core/ucsc/bedgraphtobigwig/meta.yml
@@ -1,0 +1,54 @@
+name: ucsc_bedgraphtobigwig
+description: Convert a bedGraph file to bigWig format.
+keywords:
+  - bedgraph
+  - bigwig
+  - ucsc
+  - bedgraphtobigwig
+  - converter
+tools:
+  - ucsc:
+      description: Convert a bedGraph file to bigWig format.
+      homepage: http://hgdownload.cse.ucsc.edu/admin/exe/
+      documentation: https://genome.ucsc.edu/goldenPath/help/bigWig.html
+      licence: ["varies; see http://genome.ucsc.edu/license"]
+      identifier: ""
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:false ]
+    - bedgraph:
+        type: file
+        description: bedGraph file
+        pattern: "*.{bedGraph}"
+        ontologies: []
+  - sizes:
+      type: file
+      description: chromosome sizes file
+      pattern: "*.{sizes}"
+      ontologies: []
+output:
+  bigwig:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.bigWig":
+          type: file
+          description: bigWig file
+          pattern: "*.{bigWig}"
+          ontologies: []
+  versions:
+    - versions.yml:
+        type: file
+        description: File containing software versions
+        pattern: "versions.yml"
+        ontologies:
+          - edam: http://edamontology.org/format_3750 # YAML
+authors:
+  - "@drpatelh"
+maintainers:
+  - "@drpatelh"

--- a/modules/nf-core/ucsc/bedgraphtobigwig/tests/main.nf.test
+++ b/modules/nf-core/ucsc/bedgraphtobigwig/tests/main.nf.test
@@ -1,0 +1,53 @@
+nextflow_process {
+
+    name "Test Process UCSC_BEDGRAPHTOBIGWIG"
+    script "../main.nf"
+    process "UCSC_BEDGRAPHTOBIGWIG"
+    tag "modules"
+    tag "modules_nfcore"
+    tag "ucsc"
+    tag "ucsc/bedgraphtobigwig"
+
+    test("Should run without failures") {
+        when {
+            process {
+                """
+                input[0] = Channel.of([
+                    [ id:'test' ], // meta map
+                    file(params.modules_testdata_base_path + "genomics/sarscov2/illumina/bedgraph/test.bedgraph", checkIfExists: true)
+                ])
+                input[1] = Channel.of(file(params.modules_testdata_base_path + "genomics/sarscov2/genome/genome.sizes", checkIfExists: true))
+                """
+            }
+        }
+
+        then {
+            assertAll (
+            { assert process.success },
+            { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("stub") {
+        options "-stub"
+        when {
+            process {
+                """
+                input[0] = Channel.of([
+                    [ id:'test' ], // meta map
+                    file(params.modules_testdata_base_path + "genomics/sarscov2/illumina/bedgraph/test.bedgraph", checkIfExists: true)
+                ])
+                input[1] = Channel.of(file(params.modules_testdata_base_path + "genomics/sarscov2/genome/genome.sizes", checkIfExists: true))
+                """
+            }
+        }
+
+        then {
+            assertAll (
+            { assert process.success },
+            { assert snapshot(process.out).match() }
+            )
+        }
+    }
+}

--- a/modules/nf-core/ucsc/bedgraphtobigwig/tests/main.nf.test.snap
+++ b/modules/nf-core/ucsc/bedgraphtobigwig/tests/main.nf.test.snap
@@ -1,0 +1,68 @@
+{
+    "stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.bigWig:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,db26514184acfdf220bb2f061382cf8c"
+                ],
+                "bigwig": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.bigWig:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,db26514184acfdf220bb2f061382cf8c"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.0",
+            "nextflow": "24.04.4"
+        },
+        "timestamp": "2024-10-18T10:47:58.558813949"
+    },
+    "Should run without failures": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.bigWig:md5,910ecc7f57e3bbd5fac5a8edba4f615d"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,db26514184acfdf220bb2f061382cf8c"
+                ],
+                "bigwig": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.bigWig:md5,910ecc7f57e3bbd5fac5a8edba4f615d"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,db26514184acfdf220bb2f061382cf8c"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.0",
+            "nextflow": "24.04.4"
+        },
+        "timestamp": "2024-10-18T10:47:36.476844229"
+    }
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -89,6 +89,9 @@ params {
     skip_fastqc                = false
     skip_multiqc               = false
 
+    // Coverage
+    skip_coverage_tracks       = false
+
     // Riboseq module-specific options
     skip_ribotish                        = false
     extra_ribotish_quality_args          = null

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -672,6 +672,11 @@
                     "fa_icon": "fas fa-fast-forward",
                     "description": "Skip all QC steps except for MultiQC."
                 },
+                "skip_coverage_tracks": {
+                    "type": "boolean",
+                    "description": "Skip bigWig coverage track generation.",
+                    "fa_icon": "fas fa-fast-forward"
+                },
                 "skip_ribotish": {
                     "type": "boolean",
                     "description": "Skip Ribo-TISH.",

--- a/tests/default.nf.test.snap
+++ b/tests/default.nf.test.snap
@@ -5,6 +5,9 @@
                 "ANOTA2SEQ_ANOTA2SEQRUN": {
                     "bioconductor-anota2seq": "1.24.0"
                 },
+                "BEDTOOLS_GENOMECOV": {
+                    "bedtools": "2.31.1"
+                },
                 "CUSTOM_GETCHROMSIZES": {
                     "getchromsizes": 1.21
                 },
@@ -101,6 +104,9 @@
                 },
                 "TXIMETA_TXIMPORT": {
                     "bioconductor-tximeta": "1.20.1"
+                },
+                "UCSC_BEDGRAPHTOBIGWIG": {
+                    "ucsc": 469
                 },
                 "Workflow": {
                     "nf-core/riboseq": "v1.3.0dev"
@@ -306,6 +312,25 @@
                 "alignment/star/sorted/samtools_stats/SRX11780890.transcriptome.sorted.bam.idxstats",
                 "alignment/star/sorted/samtools_stats/SRX11780890.transcriptome.sorted.bam.stats",
                 "alignment/star/unmapped",
+                "coverage",
+                "coverage/SRX11780879.unstranded.bigWig",
+                "coverage/SRX11780880.unstranded.bigWig",
+                "coverage/SRX11780881.unstranded.bigWig",
+                "coverage/SRX11780882.unstranded.bigWig",
+                "coverage/SRX11780883.unstranded.bigWig",
+                "coverage/SRX11780884.unstranded.bigWig",
+                "coverage/SRX11780885.forward.bigWig",
+                "coverage/SRX11780885.reverse.bigWig",
+                "coverage/SRX11780886.forward.bigWig",
+                "coverage/SRX11780886.reverse.bigWig",
+                "coverage/SRX11780887.forward.bigWig",
+                "coverage/SRX11780887.reverse.bigWig",
+                "coverage/SRX11780888.forward.bigWig",
+                "coverage/SRX11780888.reverse.bigWig",
+                "coverage/SRX11780889.forward.bigWig",
+                "coverage/SRX11780889.reverse.bigWig",
+                "coverage/SRX11780890.forward.bigWig",
+                "coverage/SRX11780890.reverse.bigWig",
                 "genome",
                 "genome/index",
                 "genome/sortmerna",
@@ -1195,6 +1220,24 @@
                 "SRX11780890.genome.sorted.bam.idxstats:md5,ddf523e4a8f0c5bd1a34f8f689cd4ae6",
                 "SRX11780890.transcriptome.sorted.bam.flagstat:md5,a1ea1f12badc1db07cecb4633c6229e0",
                 "SRX11780890.transcriptome.sorted.bam.idxstats:md5,2153eb76d34dfd9b2be396c919081871",
+                "SRX11780879.unstranded.bigWig:md5,435395dc3facca95716cf37458586d04",
+                "SRX11780880.unstranded.bigWig:md5,13f32001475a204201ced76584d6a955",
+                "SRX11780881.unstranded.bigWig:md5,6e17b06b74229ba2ccf5cecab21826e2",
+                "SRX11780882.unstranded.bigWig:md5,1002522e0949f63efd4acadb5a83830f",
+                "SRX11780883.unstranded.bigWig:md5,9dd05faf5d218a48ff116755bcbc5f22",
+                "SRX11780884.unstranded.bigWig:md5,2bb03fca83e71a11220ec0640d547a23",
+                "SRX11780885.forward.bigWig:md5,151792df103f7ab958ce486f9d75d810",
+                "SRX11780885.reverse.bigWig:md5,d8d62a3530b0dbb8ce3d033aebb4c777",
+                "SRX11780886.forward.bigWig:md5,4c47df3f88a5bdaab4b5f74acaacd94d",
+                "SRX11780886.reverse.bigWig:md5,c9292c0db79cf971389410a1cf8230eb",
+                "SRX11780887.forward.bigWig:md5,1d7e53797ca6436262474a00b8a22d3d",
+                "SRX11780887.reverse.bigWig:md5,42888ba498090ee44c189a8841a4712e",
+                "SRX11780888.forward.bigWig:md5,39af51f3611526d0292cdd492d6b19d9",
+                "SRX11780888.reverse.bigWig:md5,b1017f0a5b28b0f1fd533731fb6af8ca",
+                "SRX11780889.forward.bigWig:md5,5bc7e2f9311b74123153d718248d069b",
+                "SRX11780889.reverse.bigWig:md5,236bda3b53b6a2d3cc937d03ce402e83",
+                "SRX11780890.forward.bigWig:md5,9833a547a9c4b00cc3bb82aa15ebd2a9",
+                "SRX11780890.reverse.bigWig:md5,c37d1a7ccb3a3581d7b29b0f9221b81d",
                 "cutadapt_filtered_reads_plot.txt:md5,ff95c965185e62ff5914a5c60e7a268f",
                 "cutadapt_trimmed_sequences_plot_3_Counts.txt:md5,319e9bb90c170c4b0207d644926bf69a",
                 "cutadapt_trimmed_sequences_plot_3_Obs_Exp.txt:md5,6ed5bbd0961572352d1614cc1f25f29d",
@@ -1370,8 +1413,8 @@
         ],
         "meta": {
             "nf-test": "0.9.3",
-            "nextflow": "25.10.0"
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2026-01-12T11:25:43.71297576"
+        "timestamp": "2026-01-20T12:31:33.016134913"
     }
 }

--- a/tests/deltate.nf.test.snap
+++ b/tests/deltate.nf.test.snap
@@ -2,6 +2,9 @@
     "-profile test --translational_efficiency_method deltate": {
         "content": [
             {
+                "BEDTOOLS_GENOMECOV": {
+                    "bedtools": "2.31.1"
+                },
                 "BOWTIE2_ALIGN": {
                     "bowtie2": "2.5.4",
                     "pigz": 2.8,
@@ -120,6 +123,9 @@
                 },
                 "TXIMETA_TXIMPORT": {
                     "bioconductor-tximeta": "1.20.1"
+                },
+                "UCSC_BEDGRAPHTOBIGWIG": {
+                    "ucsc": 469
                 },
                 "Workflow": {
                     "nf-core/riboseq": "v1.3.0dev"
@@ -325,6 +331,25 @@
                 "alignment/star/sorted/samtools_stats/SRX11780890.transcriptome.sorted.bam.idxstats",
                 "alignment/star/sorted/samtools_stats/SRX11780890.transcriptome.sorted.bam.stats",
                 "alignment/star/unmapped",
+                "coverage",
+                "coverage/SRX11780879.unstranded.bigWig",
+                "coverage/SRX11780880.unstranded.bigWig",
+                "coverage/SRX11780881.unstranded.bigWig",
+                "coverage/SRX11780882.unstranded.bigWig",
+                "coverage/SRX11780883.unstranded.bigWig",
+                "coverage/SRX11780884.unstranded.bigWig",
+                "coverage/SRX11780885.forward.bigWig",
+                "coverage/SRX11780885.reverse.bigWig",
+                "coverage/SRX11780886.forward.bigWig",
+                "coverage/SRX11780886.reverse.bigWig",
+                "coverage/SRX11780887.forward.bigWig",
+                "coverage/SRX11780887.reverse.bigWig",
+                "coverage/SRX11780888.forward.bigWig",
+                "coverage/SRX11780888.reverse.bigWig",
+                "coverage/SRX11780889.forward.bigWig",
+                "coverage/SRX11780889.reverse.bigWig",
+                "coverage/SRX11780890.forward.bigWig",
+                "coverage/SRX11780890.reverse.bigWig",
                 "genome",
                 "genome/bowtie2_rrna",
                 "genome/index",
@@ -1226,6 +1251,24 @@
                 "SRX11780890.genome.sorted.bam.idxstats:md5,3a0b29a35c233c8a44da429c0c1c4051",
                 "SRX11780890.transcriptome.sorted.bam.flagstat:md5,87173978a2990cd5da861ad20b0b6982",
                 "SRX11780890.transcriptome.sorted.bam.idxstats:md5,ae7f1daff6764bbc167742d19c99d587",
+                "SRX11780879.unstranded.bigWig:md5,23326c2cc4fe3800887db4ec86bd189a",
+                "SRX11780880.unstranded.bigWig:md5,4d245c5ed0a5065b475d3f1b59fd999d",
+                "SRX11780881.unstranded.bigWig:md5,8a4352ce599ae915045f455bbdc5c4c4",
+                "SRX11780882.unstranded.bigWig:md5,a329eb665c52757b5cfc8435420f873b",
+                "SRX11780883.unstranded.bigWig:md5,5735c191faaf56cbf69c948fbc7da02c",
+                "SRX11780884.unstranded.bigWig:md5,8846c12158f81605fcc45c3bf2be545d",
+                "SRX11780885.forward.bigWig:md5,ca38c864b57b8d0d3edc7928faf31ce8",
+                "SRX11780885.reverse.bigWig:md5,1455b40179287861439fcba6604ee187",
+                "SRX11780886.forward.bigWig:md5,5c1d2f94fb16e15a82fce5cdde491106",
+                "SRX11780886.reverse.bigWig:md5,9d72533fdc9771511f22d4fd458f33e4",
+                "SRX11780887.forward.bigWig:md5,0a9de4df784c1712915db9e4973fa0da",
+                "SRX11780887.reverse.bigWig:md5,026e824f028960951c860df1b80e6313",
+                "SRX11780888.forward.bigWig:md5,39af51f3611526d0292cdd492d6b19d9",
+                "SRX11780888.reverse.bigWig:md5,4dbcd9fb1ec67c20930a93634284175b",
+                "SRX11780889.forward.bigWig:md5,5bc7e2f9311b74123153d718248d069b",
+                "SRX11780889.reverse.bigWig:md5,67d5f74d348932af17f2a5e7d943e89b",
+                "SRX11780890.forward.bigWig:md5,9833a547a9c4b00cc3bb82aa15ebd2a9",
+                "SRX11780890.reverse.bigWig:md5,212f8be71d7cc4d7917dab779c4f7695",
                 "bowtie2_pe_plot.txt:md5,b4dc3c205f64fed5094f56622512451b",
                 "bowtie2_se_plot.txt:md5,1a9cb4b686308088e524ef2b313e2f49",
                 "cutadapt_filtered_reads_plot.txt:md5,ff95c965185e62ff5914a5c60e7a268f",
@@ -1414,8 +1457,8 @@
         ],
         "meta": {
             "nf-test": "0.9.3",
-            "nextflow": "25.10.0"
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2026-01-12T11:49:33.454689536"
+        "timestamp": "2026-01-20T12:39:11.283258096"
     }
 }

--- a/tests/equalise_read_lengths.nf.test.snap
+++ b/tests/equalise_read_lengths.nf.test.snap
@@ -5,6 +5,9 @@
                 "ANOTA2SEQ_ANOTA2SEQRUN": {
                     "bioconductor-anota2seq": "1.24.0"
                 },
+                "BEDTOOLS_GENOMECOV": {
+                    "bedtools": "2.31.1"
+                },
                 "BOWTIE2_ALIGN": {
                     "bowtie2": "2.5.4",
                     "pigz": 2.8,
@@ -125,6 +128,9 @@
                 },
                 "TXIMETA_TXIMPORT": {
                     "bioconductor-tximeta": "1.20.1"
+                },
+                "UCSC_BEDGRAPHTOBIGWIG": {
+                    "ucsc": 469
                 },
                 "Workflow": {
                     "nf-core/riboseq": "v1.3.0dev"
@@ -330,6 +336,25 @@
                 "alignment/star/sorted/samtools_stats/SRX11780890.transcriptome.sorted.bam.idxstats",
                 "alignment/star/sorted/samtools_stats/SRX11780890.transcriptome.sorted.bam.stats",
                 "alignment/star/unmapped",
+                "coverage",
+                "coverage/SRX11780879.unstranded.bigWig",
+                "coverage/SRX11780880.unstranded.bigWig",
+                "coverage/SRX11780881.unstranded.bigWig",
+                "coverage/SRX11780882.unstranded.bigWig",
+                "coverage/SRX11780883.unstranded.bigWig",
+                "coverage/SRX11780884.unstranded.bigWig",
+                "coverage/SRX11780885.forward.bigWig",
+                "coverage/SRX11780885.reverse.bigWig",
+                "coverage/SRX11780886.forward.bigWig",
+                "coverage/SRX11780886.reverse.bigWig",
+                "coverage/SRX11780887.forward.bigWig",
+                "coverage/SRX11780887.reverse.bigWig",
+                "coverage/SRX11780888.forward.bigWig",
+                "coverage/SRX11780888.reverse.bigWig",
+                "coverage/SRX11780889.forward.bigWig",
+                "coverage/SRX11780889.reverse.bigWig",
+                "coverage/SRX11780890.forward.bigWig",
+                "coverage/SRX11780890.reverse.bigWig",
                 "genome",
                 "genome/bowtie2_rrna",
                 "genome/index",
@@ -1243,6 +1268,24 @@
                 "SRX11780890.genome.sorted.bam.idxstats:md5,3a0b29a35c233c8a44da429c0c1c4051",
                 "SRX11780890.transcriptome.sorted.bam.flagstat:md5,87173978a2990cd5da861ad20b0b6982",
                 "SRX11780890.transcriptome.sorted.bam.idxstats:md5,ae7f1daff6764bbc167742d19c99d587",
+                "SRX11780879.unstranded.bigWig:md5,545ae301f4904c41f715dcfb71c9821a",
+                "SRX11780880.unstranded.bigWig:md5,b07e16fc380106f4c9a515668c5b5cd5",
+                "SRX11780881.unstranded.bigWig:md5,9c3f20ef6c37bd188ca0058654471f11",
+                "SRX11780882.unstranded.bigWig:md5,11502983f9caaacc75f93233097d8b5c",
+                "SRX11780883.unstranded.bigWig:md5,73485e44c03f2cc09e8341a4f7f10638",
+                "SRX11780884.unstranded.bigWig:md5,03aaba982214d1b49e0409b0e4e2d316",
+                "SRX11780885.forward.bigWig:md5,ca38c864b57b8d0d3edc7928faf31ce8",
+                "SRX11780885.reverse.bigWig:md5,1455b40179287861439fcba6604ee187",
+                "SRX11780886.forward.bigWig:md5,5c1d2f94fb16e15a82fce5cdde491106",
+                "SRX11780886.reverse.bigWig:md5,9d72533fdc9771511f22d4fd458f33e4",
+                "SRX11780887.forward.bigWig:md5,0a9de4df784c1712915db9e4973fa0da",
+                "SRX11780887.reverse.bigWig:md5,026e824f028960951c860df1b80e6313",
+                "SRX11780888.forward.bigWig:md5,39af51f3611526d0292cdd492d6b19d9",
+                "SRX11780888.reverse.bigWig:md5,4dbcd9fb1ec67c20930a93634284175b",
+                "SRX11780889.forward.bigWig:md5,5bc7e2f9311b74123153d718248d069b",
+                "SRX11780889.reverse.bigWig:md5,67d5f74d348932af17f2a5e7d943e89b",
+                "SRX11780890.forward.bigWig:md5,9833a547a9c4b00cc3bb82aa15ebd2a9",
+                "SRX11780890.reverse.bigWig:md5,212f8be71d7cc4d7917dab779c4f7695",
                 "bowtie2_pe_plot.txt:md5,b4dc3c205f64fed5094f56622512451b",
                 "bowtie2_se_plot.txt:md5,1a9cb4b686308088e524ef2b313e2f49",
                 "cutadapt_filtered_reads_plot.txt:md5,ff95c965185e62ff5914a5c60e7a268f",
@@ -1440,8 +1483,8 @@
         ],
         "meta": {
             "nf-test": "0.9.3",
-            "nextflow": "25.10.0"
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2026-01-12T12:06:06.727279212"
+        "timestamp": "2026-01-20T12:46:10.576656486"
     }
 }

--- a/tests/ribo_removal_bowtie2.nf.test.snap
+++ b/tests/ribo_removal_bowtie2.nf.test.snap
@@ -5,6 +5,9 @@
                 "ANOTA2SEQ_ANOTA2SEQRUN": {
                     "bioconductor-anota2seq": "1.24.0"
                 },
+                "BEDTOOLS_GENOMECOV": {
+                    "bedtools": "2.31.1"
+                },
                 "BOWTIE2_ALIGN": {
                     "bowtie2": "2.5.4",
                     "pigz": 2.8,
@@ -117,6 +120,9 @@
                 },
                 "TXIMETA_TXIMPORT": {
                     "bioconductor-tximeta": "1.20.1"
+                },
+                "UCSC_BEDGRAPHTOBIGWIG": {
+                    "ucsc": 469
                 },
                 "Workflow": {
                     "nf-core/riboseq": "v1.3.0dev"
@@ -322,6 +328,25 @@
                 "alignment/star/sorted/samtools_stats/SRX11780890.transcriptome.sorted.bam.idxstats",
                 "alignment/star/sorted/samtools_stats/SRX11780890.transcriptome.sorted.bam.stats",
                 "alignment/star/unmapped",
+                "coverage",
+                "coverage/SRX11780879.unstranded.bigWig",
+                "coverage/SRX11780880.unstranded.bigWig",
+                "coverage/SRX11780881.unstranded.bigWig",
+                "coverage/SRX11780882.unstranded.bigWig",
+                "coverage/SRX11780883.unstranded.bigWig",
+                "coverage/SRX11780884.unstranded.bigWig",
+                "coverage/SRX11780885.forward.bigWig",
+                "coverage/SRX11780885.reverse.bigWig",
+                "coverage/SRX11780886.forward.bigWig",
+                "coverage/SRX11780886.reverse.bigWig",
+                "coverage/SRX11780887.forward.bigWig",
+                "coverage/SRX11780887.reverse.bigWig",
+                "coverage/SRX11780888.forward.bigWig",
+                "coverage/SRX11780888.reverse.bigWig",
+                "coverage/SRX11780889.forward.bigWig",
+                "coverage/SRX11780889.reverse.bigWig",
+                "coverage/SRX11780890.forward.bigWig",
+                "coverage/SRX11780890.reverse.bigWig",
                 "genome",
                 "genome/bowtie2_rrna",
                 "genome/index",
@@ -1218,6 +1243,24 @@
                 "SRX11780890.genome.sorted.bam.idxstats:md5,3a0b29a35c233c8a44da429c0c1c4051",
                 "SRX11780890.transcriptome.sorted.bam.flagstat:md5,87173978a2990cd5da861ad20b0b6982",
                 "SRX11780890.transcriptome.sorted.bam.idxstats:md5,ae7f1daff6764bbc167742d19c99d587",
+                "SRX11780879.unstranded.bigWig:md5,23326c2cc4fe3800887db4ec86bd189a",
+                "SRX11780880.unstranded.bigWig:md5,4d245c5ed0a5065b475d3f1b59fd999d",
+                "SRX11780881.unstranded.bigWig:md5,8a4352ce599ae915045f455bbdc5c4c4",
+                "SRX11780882.unstranded.bigWig:md5,a329eb665c52757b5cfc8435420f873b",
+                "SRX11780883.unstranded.bigWig:md5,5735c191faaf56cbf69c948fbc7da02c",
+                "SRX11780884.unstranded.bigWig:md5,8846c12158f81605fcc45c3bf2be545d",
+                "SRX11780885.forward.bigWig:md5,ca38c864b57b8d0d3edc7928faf31ce8",
+                "SRX11780885.reverse.bigWig:md5,1455b40179287861439fcba6604ee187",
+                "SRX11780886.forward.bigWig:md5,5c1d2f94fb16e15a82fce5cdde491106",
+                "SRX11780886.reverse.bigWig:md5,9d72533fdc9771511f22d4fd458f33e4",
+                "SRX11780887.forward.bigWig:md5,0a9de4df784c1712915db9e4973fa0da",
+                "SRX11780887.reverse.bigWig:md5,026e824f028960951c860df1b80e6313",
+                "SRX11780888.forward.bigWig:md5,39af51f3611526d0292cdd492d6b19d9",
+                "SRX11780888.reverse.bigWig:md5,4dbcd9fb1ec67c20930a93634284175b",
+                "SRX11780889.forward.bigWig:md5,5bc7e2f9311b74123153d718248d069b",
+                "SRX11780889.reverse.bigWig:md5,67d5f74d348932af17f2a5e7d943e89b",
+                "SRX11780890.forward.bigWig:md5,9833a547a9c4b00cc3bb82aa15ebd2a9",
+                "SRX11780890.reverse.bigWig:md5,212f8be71d7cc4d7917dab779c4f7695",
                 "bowtie2_pe_plot.txt:md5,b4dc3c205f64fed5094f56622512451b",
                 "bowtie2_se_plot.txt:md5,1a9cb4b686308088e524ef2b313e2f49",
                 "cutadapt_filtered_reads_plot.txt:md5,ff95c965185e62ff5914a5c60e7a268f",
@@ -1406,8 +1449,8 @@
         ],
         "meta": {
             "nf-test": "0.9.3",
-            "nextflow": "25.10.0"
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2026-01-12T12:13:40.704565835"
+        "timestamp": "2026-01-20T12:53:12.269669641"
     }
 }

--- a/tests/te_pseudo_alignment.nf.test.snap
+++ b/tests/te_pseudo_alignment.nf.test.snap
@@ -5,6 +5,9 @@
                 "ANOTA2SEQ_ANOTA2SEQRUN": {
                     "bioconductor-anota2seq": "1.24.0"
                 },
+                "BEDTOOLS_GENOMECOV": {
+                    "bedtools": "2.31.1"
+                },
                 "BOWTIE2_ALIGN": {
                     "bowtie2": "2.5.4",
                     "pigz": 2.8,
@@ -120,6 +123,9 @@
                 },
                 "TXIMETA_TXIMPORT": {
                     "bioconductor-tximeta": "1.20.1"
+                },
+                "UCSC_BEDGRAPHTOBIGWIG": {
+                    "ucsc": 469
                 },
                 "Workflow": {
                     "nf-core/riboseq": "v1.3.0dev"
@@ -325,6 +331,25 @@
                 "alignment/star/sorted/samtools_stats/SRX11780890.transcriptome.sorted.bam.idxstats",
                 "alignment/star/sorted/samtools_stats/SRX11780890.transcriptome.sorted.bam.stats",
                 "alignment/star/unmapped",
+                "coverage",
+                "coverage/SRX11780879.unstranded.bigWig",
+                "coverage/SRX11780880.unstranded.bigWig",
+                "coverage/SRX11780881.unstranded.bigWig",
+                "coverage/SRX11780882.unstranded.bigWig",
+                "coverage/SRX11780883.unstranded.bigWig",
+                "coverage/SRX11780884.unstranded.bigWig",
+                "coverage/SRX11780885.forward.bigWig",
+                "coverage/SRX11780885.reverse.bigWig",
+                "coverage/SRX11780886.forward.bigWig",
+                "coverage/SRX11780886.reverse.bigWig",
+                "coverage/SRX11780887.forward.bigWig",
+                "coverage/SRX11780887.reverse.bigWig",
+                "coverage/SRX11780888.forward.bigWig",
+                "coverage/SRX11780888.reverse.bigWig",
+                "coverage/SRX11780889.forward.bigWig",
+                "coverage/SRX11780889.reverse.bigWig",
+                "coverage/SRX11780890.forward.bigWig",
+                "coverage/SRX11780890.reverse.bigWig",
                 "genome",
                 "genome/bowtie2_rrna",
                 "genome/index",
@@ -1440,6 +1465,24 @@
                 "SRX11780890.genome.sorted.bam.idxstats:md5,3a0b29a35c233c8a44da429c0c1c4051",
                 "SRX11780890.transcriptome.sorted.bam.flagstat:md5,87173978a2990cd5da861ad20b0b6982",
                 "SRX11780890.transcriptome.sorted.bam.idxstats:md5,ae7f1daff6764bbc167742d19c99d587",
+                "SRX11780879.unstranded.bigWig:md5,23326c2cc4fe3800887db4ec86bd189a",
+                "SRX11780880.unstranded.bigWig:md5,4d245c5ed0a5065b475d3f1b59fd999d",
+                "SRX11780881.unstranded.bigWig:md5,8a4352ce599ae915045f455bbdc5c4c4",
+                "SRX11780882.unstranded.bigWig:md5,a329eb665c52757b5cfc8435420f873b",
+                "SRX11780883.unstranded.bigWig:md5,5735c191faaf56cbf69c948fbc7da02c",
+                "SRX11780884.unstranded.bigWig:md5,8846c12158f81605fcc45c3bf2be545d",
+                "SRX11780885.forward.bigWig:md5,ca38c864b57b8d0d3edc7928faf31ce8",
+                "SRX11780885.reverse.bigWig:md5,1455b40179287861439fcba6604ee187",
+                "SRX11780886.forward.bigWig:md5,5c1d2f94fb16e15a82fce5cdde491106",
+                "SRX11780886.reverse.bigWig:md5,9d72533fdc9771511f22d4fd458f33e4",
+                "SRX11780887.forward.bigWig:md5,0a9de4df784c1712915db9e4973fa0da",
+                "SRX11780887.reverse.bigWig:md5,026e824f028960951c860df1b80e6313",
+                "SRX11780888.forward.bigWig:md5,39af51f3611526d0292cdd492d6b19d9",
+                "SRX11780888.reverse.bigWig:md5,4dbcd9fb1ec67c20930a93634284175b",
+                "SRX11780889.forward.bigWig:md5,5bc7e2f9311b74123153d718248d069b",
+                "SRX11780889.reverse.bigWig:md5,67d5f74d348932af17f2a5e7d943e89b",
+                "SRX11780890.forward.bigWig:md5,9833a547a9c4b00cc3bb82aa15ebd2a9",
+                "SRX11780890.reverse.bigWig:md5,212f8be71d7cc4d7917dab779c4f7695",
                 "bowtie2_pe_plot.txt:md5,b4dc3c205f64fed5094f56622512451b",
                 "bowtie2_se_plot.txt:md5,1a9cb4b686308088e524ef2b313e2f49",
                 "cutadapt_filtered_reads_plot.txt:md5,ff95c965185e62ff5914a5c60e7a268f",
@@ -1717,6 +1760,6 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.2"
         },
-        "timestamp": "2026-01-13T14:34:24.991558174"
+        "timestamp": "2026-01-20T13:00:38.972698231"
     }
 }

--- a/workflows/riboseq/main.nf
+++ b/workflows/riboseq/main.nf
@@ -67,6 +67,15 @@ include { validateInputSamplesheet } from '../../subworkflows/local/utils_nfcore
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 */
 
+// A filter for samtools view which splits alignments by first-of-pair strand,
+// taking into consideration the strandedness of the library. Used by SAMTOOLS_VIEW_SPLIT_BY_STRAND.
+def getStrandFilter(strandedness, strand) {
+    def sameOrientation = (strand == 'forward') == (strandedness == 'forward')
+    sameOrientation
+        ? "-e '((flag.read1 || !flag.paired) && !flag.reverse) || (flag.read2 &&  flag.reverse)'"
+        : "-e '((flag.read1 || !flag.paired) &&  flag.reverse) || (flag.read2 && !flag.reverse)'"
+}
+
 workflow RIBOSEQ {
 
     take:
@@ -276,8 +285,12 @@ workflow RIBOSEQ {
             .filter { meta, bam, bai -> meta.strandedness in ['forward', 'reverse'] }
         SAMTOOLS_VIEW_SPLIT_BY_STRAND(
             ch_split_by_strand
-                .map                        { meta, bam, bai -> [meta + [strand: 'forward'], bam, bai] }
-                .mix(ch_split_by_strand.map { meta, bam, bai -> [meta + [strand: 'reverse'], bam, bai] }),
+                .flatMap { meta, bam, bai ->
+                    ['forward', 'reverse'].collect { strand ->
+                        [meta + [strand: strand, strand_filter:
+                            getStrandFilter(meta.strandedness, strand)], bam, bai]
+                    }
+                },
             [[], []],  // No reference fasta
             [],        // No qname file
             []         // No index format

--- a/workflows/riboseq/main.nf
+++ b/workflows/riboseq/main.nf
@@ -44,6 +44,9 @@ include { RIBOWALTZ                                            } from '../../mod
 include { PLASTID_METAGENE_GENERATE                            } from '../../modules/nf-core/plastid/metagene_generate/main'
 include { PLASTID_PSITE                                        } from '../../modules/nf-core/plastid/psite/main'
 include { PLASTID_MAKE_WIGGLE                                  } from '../../modules/nf-core/plastid/make_wiggle/main'
+include { SAMTOOLS_VIEW as SAMTOOLS_VIEW_SPLIT_BY_STRAND       } from '../../modules/nf-core/samtools/view'
+include { BEDTOOLS_GENOMECOV                                   } from '../../modules/nf-core/bedtools/genomecov/main'
+include { UCSC_BEDGRAPHTOBIGWIG                                } from '../../modules/nf-core/ucsc/bedgraphtobigwig/main'
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -259,6 +262,48 @@ workflow RIBOSEQ {
 
         ch_multiqc_files = ch_multiqc_files
             .mix(BAM_DEDUP_UMI.out.multiqc_files)
+    }
+
+    //
+    // Generate coverage tracks
+    //
+
+    if (!params.skip_coverage_tracks) {
+
+        // When protocol is stranded, split BAMs by mate1 strand
+        ch_split_by_strand = ch_genome_bam
+            .join(ch_genome_bam_index, by: [0])
+            .filter { meta, bam, bai -> meta.strandedness in ['forward', 'reverse'] }
+        SAMTOOLS_VIEW_SPLIT_BY_STRAND(
+            ch_split_by_strand
+                .map                        { meta, bam, bai -> [meta + [strand: 'forward'], bam, bai] }
+                .mix(ch_split_by_strand.map { meta, bam, bai -> [meta + [strand: 'reverse'], bam, bai] }),
+            [[], []],  // No reference fasta
+            [],        // No qname file
+            []         // No index format
+        )
+
+        // Create bedgraph tracks
+        BEDTOOLS_GENOMECOV(
+            SAMTOOLS_VIEW_SPLIT_BY_STRAND.out.bam
+                .map { meta, bam -> [meta, bam, 1] }
+                .mix(ch_genome_bam
+                    .filter { meta, bam -> meta.strandedness == 'unstranded' }
+                    .map { meta, bam -> [meta + [strand: 'unstranded'], bam, 1] }
+                ),
+            ch_fai,
+            'bedgraph',
+            false
+        )
+        ch_versions = ch_versions.mix(BEDTOOLS_GENOMECOV.out.versions)
+
+        // Convert bedgraphs to bigWig
+        UCSC_BEDGRAPHTOBIGWIG(
+            BEDTOOLS_GENOMECOV.out.genomecov,
+            ch_fai
+        )
+        ch_versions = ch_versions.mix(UCSC_BEDGRAPHTOBIGWIG.out.versions)
+
     }
 
     //


### PR DESCRIPTION
I have added bigWig coverage tracks to the outputs using `bedtools genomecov`. Stranded libraries produce two tracks, `<SAMPLE>.forward.bigWig` and `<SAMPLE>.reverse.bigWig`. Unstranded libraries produce a single track `<SAMPLE>.unstranded.bigWig`.

The track creation needed to be divided into three processes:
1. Splitting BAMs into forward and reverse reads, because `bedtools genomecov` does not handle the strand of paired-end mates properly (it always uses the strand of the mate, not the strand of the first-of-pair)
2. Conversion of the split BAMs to bedGraph
3. Conversion of the bedGraphs to bigWig to reduce storage consumption

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [X] If you've fixed a bug or added code that should be tested, add tests!
- [X] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/riboseq/tree/master/.github/CONTRIBUTING.md)
- [X] Make sure your code lints (`nf-core pipelines lint`).
- [X] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [X] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [X] Output Documentation in `docs/output.md` is updated.
- [X] `CHANGELOG.md` is updated.
- [X] `README.md` is updated (including new tool citations and authors/contributors).
