### PR TITLE
Update ribodetector module to 0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Changed`
 
 - [#129](https://github.com/nf-core/riboseq/pull/129) - Bump pipeline version to 1.3.0dev ([@iraiosub](https://github.com/iraiosub))
+- [#152](https://github.com/nf-core/riboseq/pull/152) - Update ribodetector module to 0.3.3 (nf-core/modules#11131) ([@pinin4fjords](https://github.com/pinin4fjords))
 
 ### `Parameters`
 

--- a/modules.json
+++ b/modules.json
@@ -137,7 +137,7 @@
                     },
                     "ribodetector": {
                         "branch": "master",
-                        "git_sha": "5cb9a8694da0a0e550921636bb60bc8c56445fd7",
+                        "git_sha": "278c4ebdaa1c51fa0dc1b09be0da2b53962a87f5",
                         "installed_by": ["fastq_remove_rrna"]
                     },
                     "ribotish/predict": {

--- a/modules/nf-core/ribodetector/environment.yml
+++ b/modules/nf-core/ribodetector/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - "bioconda::ribodetector=0.3.2"
+  - "bioconda::ribodetector=0.3.3"

--- a/modules/nf-core/ribodetector/main.nf
+++ b/modules/nf-core/ribodetector/main.nf
@@ -4,8 +4,8 @@ process RIBODETECTOR {
 
 	conda "${moduleDir}/environment.yml"
 	container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/4d/4de8fe74d21198e6fc8218cb3209d929b3d7dab750678501b096b0ccc324307b/data' :
-        'community.wave.seqera.io/library/ribodetector:0.3.2--cbe1c77fa14eeb53' }"
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/46/463b8ad941e7f1f2decef20844d666c1c8ac233e166d2bc766164c4a93905a3c/data' :
+        'community.wave.seqera.io/library/ribodetector:0.3.3--ad3d7071e408b502' }"
 
 	input:
 	tuple val(meta), path(fastq)

--- a/modules/nf-core/ribodetector/tests/main.nf.test.snap
+++ b/modules/nf-core/ribodetector/tests/main.nf.test.snap
@@ -6,7 +6,7 @@
                     [
                         "RIBODETECTOR",
                         "ribodetector",
-                        "0.3.2"
+                        "0.3.3"
                     ]
                 ]
             }
@@ -45,7 +45,7 @@
                     [
                         "RIBODETECTOR",
                         "ribodetector",
-                        "0.3.2"
+                        "0.3.3"
                     ]
                 ],
                 "fastq": [
@@ -73,7 +73,7 @@
                     [
                         "RIBODETECTOR",
                         "ribodetector",
-                        "0.3.2"
+                        "0.3.3"
                     ]
                 ]
             }


### PR DESCRIPTION
## Summary
- Update ribodetector module from 0.3.2 to 0.3.3
- Upstream: nf-core/modules#11131

## Test plan
- [ ] CI passes with updated module

🤖 Generated with [Claude Code](https://claude.com/claude-code)