### PR TITLE
ci: Add cleanup blocks to pipeline tests

### DIFF
--- a/tests/default.nf.test
+++ b/tests/default.nf.test
@@ -31,5 +31,12 @@ nextflow_pipeline {
                 ).match() }
             )
         }
+
+        cleanup {
+            if (System.getenv("NFT_PROFILE")?.contains("docker")) {
+                "docker system prune -f".execute()
+            }
+            new File("${launchDir}").deleteDir()
+        }
     }
 }

--- a/tests/deltate.nf.test
+++ b/tests/deltate.nf.test
@@ -34,5 +34,12 @@ nextflow_pipeline {
                 ).match() }
             )
         }
+
+        cleanup {
+            if (System.getenv("NFT_PROFILE")?.contains("docker")) {
+                "docker system prune -f".execute()
+            }
+            new File("${launchDir}").deleteDir()
+        }
     }
 }

--- a/tests/equalise_read_lengths.nf.test
+++ b/tests/equalise_read_lengths.nf.test
@@ -40,5 +40,12 @@ nextflow_pipeline {
                 ).match() }
             )
         }
+
+        cleanup {
+            if (System.getenv("NFT_PROFILE")?.contains("docker")) {
+                "docker system prune -f".execute()
+            }
+            new File("${launchDir}").deleteDir()
+        }
     }
 }

--- a/tests/ribo_removal_bowtie2.nf.test
+++ b/tests/ribo_removal_bowtie2.nf.test
@@ -33,5 +33,12 @@ nextflow_pipeline {
                 ).match() }
             )
         }
+
+        cleanup {
+            if (System.getenv("NFT_PROFILE")?.contains("docker")) {
+                "docker system prune -f".execute()
+            }
+            new File("${launchDir}").deleteDir()
+        }
     }
 }

--- a/tests/te_pseudo_alignment.nf.test
+++ b/tests/te_pseudo_alignment.nf.test
@@ -34,5 +34,12 @@ nextflow_pipeline {
                 ).match() }
             )
         }
+
+        cleanup {
+            if (System.getenv("NFT_PROFILE")?.contains("docker")) {
+                "docker system prune -f".execute()
+            }
+            new File("${launchDir}").deleteDir()
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Add `cleanup` blocks to all 5 pipeline-level nf-test files to prune Docker images and delete `launchDir` between tests
- Prevents CI runners from running out of disk space when pulling Docker images across multiple test shards
- Mirrors the approach used in nf-core/rnaseq (1ac2d622f)

This should resolve the disk exhaustion issue seen in CI (e.g., the DESEQ2_DELTA module test failing to pull Docker images in #141).

## Test plan

- [ ] Verify pipeline tests still pass with the cleanup blocks
- [ ] Confirm CI no longer hits disk space errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)