### PR TITLE
feat(stringtie): add reference-guided novel transcript discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#141](https://github.com/nf-core/riboseq/pull/141) - Add in-frame P-site quantification method ([@suhrig](https://github.com/suhrig))
 - [#142](https://github.com/nf-core/riboseq/pull/142) - Add `ribodetector_chunk_size` parameter to control RiboDetector memory usage ([@pinin4fjords](https://github.com/pinin4fjords))
 - [#144](https://github.com/nf-core/riboseq/pull/144) - Add bigWig coverage tracks ([@suhrig](https://github.com/suhrig))
+- [#157](https://github.com/nf-core/riboseq/issues/157) - Add optional StringTie reference-guided novel transcript discovery; merged GTF feeds Ribo-TISH, Ribotricer, plastid, and the in-frame p-site quantification ([@pinin4fjords](https://github.com/pinin4fjords))
 
 ### `Fixed`
 
@@ -58,6 +59,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 |               | `--extra_plastid_make_wiggle_args`       |
 |               | `--skip_coverage_tracks`                 |
 |               | `--ribodetector_chunk_size`              |
+|               | `--skip_stringtie`                       |
+|               | `--extra_stringtie_args`                 |
+|               | `--extra_stringtie_merge_args`           |
 
 ### `Dependencies`
 
@@ -67,6 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 | `plastid`          |             | 0.6.1       |
 | `bedtools`         |             | 2.31.1      |
 | `bedGraphToBigWig` |             | 469         |
+| `StringTie`        |             | 2.2.3       |
 
 ## v1.2.0 - 2025-12-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#141](https://github.com/nf-core/riboseq/pull/141) - Add in-frame P-site quantification method ([@suhrig](https://github.com/suhrig))
 - [#142](https://github.com/nf-core/riboseq/pull/142) - Add `ribodetector_chunk_size` parameter to control RiboDetector memory usage ([@pinin4fjords](https://github.com/pinin4fjords))
 - [#144](https://github.com/nf-core/riboseq/pull/144) - Add bigWig coverage tracks ([@suhrig](https://github.com/suhrig))
-- [#157](https://github.com/nf-core/riboseq/issues/157) - Add optional StringTie reference-guided novel transcript discovery; merged GTF feeds Ribo-TISH, Ribotricer, plastid, and the in-frame p-site quantification ([@pinin4fjords](https://github.com/pinin4fjords))
+- [#157](https://github.com/nf-core/riboseq/issues/157) - Add optional StringTie reference-guided novel transcript discovery; merged GTF published as a side product (downstream wiring deferred to a follow-on, see PR #158) ([@pinin4fjords](https://github.com/pinin4fjords))
 
 ### `Fixed`
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -1062,4 +1062,30 @@ process {
         ]
     }
 
+    // `.denovo` prefix and the saveAs filter avoid a publish collision with any
+    // future standalone STRINGTIE_STRINGTIE call and drop the per-sample
+    // abundance/coverage outputs (not comparable across samples pre-merge).
+    // No `-e`: that flag would restrict output to reference transcripts and
+    // make novel discovery a silent no-op.
+    withName: 'NFCORE_RIBOSEQ:RIBOSEQ:BAM_STRINGTIE_MERGE:STRINGTIE_STRINGTIE' {
+        ext.args   = { ['-v', params.extra_stringtie_args ?: ''].join(' ').trim() }
+        ext.prefix = { "${meta.id}.denovo" }
+        publishDir = [
+            path: { "${params.outdir}/stringtie" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename ->
+                if (filename.endsWith('.transcripts.gtf')) return filename
+                return null
+            }
+        ]
+    }
+
+    withName: 'NFCORE_RIBOSEQ:RIBOSEQ:BAM_STRINGTIE_MERGE:STRINGTIE_MERGE' {
+        ext.args   = { params.extra_stringtie_merge_args ?: '' }
+        publishDir = [
+            path: { "${params.outdir}/stringtie" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
 }

--- a/docs/output.md
+++ b/docs/output.md
@@ -293,6 +293,19 @@ The pipeline produces coverage tracks in bigWig format. In the case of stranded 
   - `<SAMPLE>.reverse.bigWig`: Coverage on the reverse strand (only created for stranded libraries)
   - `<SAMPLE>.unstranded.bigWig`: Sum of coverage of forward and reverse strand (only created for unstranded libraries)
 
+## Novel transcript discovery (StringTie)
+
+When `--skip_stringtie false` is set, [StringTie](https://ccb.jhu.edu/software/stringtie/) is run per sample in reference-guided mode against the supplied GTF, and the per-sample assemblies are then merged into a unified annotation. The merged GTF is consumed downstream by the genome-BAM-side ORF callers (Ribo-TISH, Ribotricer), by plastid metagene generation, and by the in-frame p-site quantification step. RiboCode, riboWaltz, and alignment-mode Salmon stay on the reference annotation: their transcriptome BAMs were keyed to the reference at STAR alignment time, so they cannot consume a re-annotation without re-aligning.
+
+<details markdown="1">
+<summary>Output files</summary>
+
+- `stringtie/`
+  - `<SAMPLE>.denovo.transcripts.gtf`: Per-sample reference-guided assembly. The `.denovo` prefix marks these as the assembly inputs to the merge step (not the merged annotation).
+  - `stringtie_merge.gtf`: Merged annotation produced by `stringtie --merge` across all per-sample assemblies. Novel transcripts appear with `MSTRG.*` IDs.
+
+</details>
+
 ## Riboseq-specific QC
 
 Read distribution metrics around annotated protein coding regions or based on alignments alone, plus related metrics.

--- a/docs/output.md
+++ b/docs/output.md
@@ -295,7 +295,9 @@ The pipeline produces coverage tracks in bigWig format. In the case of stranded 
 
 ## Novel transcript discovery (StringTie)
 
-When `--skip_stringtie false` is set, [StringTie](https://ccb.jhu.edu/software/stringtie/) is run per sample in reference-guided mode against the supplied GTF, and the per-sample assemblies are then merged into a unified annotation. The merged GTF is consumed downstream by the genome-BAM-side ORF callers (Ribo-TISH, Ribotricer), by plastid metagene generation, and by the in-frame p-site quantification step. RiboCode, riboWaltz, and alignment-mode Salmon stay on the reference annotation: their transcriptome BAMs were keyed to the reference at STAR alignment time, so they cannot consume a re-annotation without re-aligning.
+When `--skip_stringtie false` is set, [StringTie](https://ccb.jhu.edu/software/stringtie/) is run per sample in reference-guided mode against the supplied GTF, and the per-sample assemblies are then merged into a unified annotation. The merged GTF is published as a side product for downstream use; **the rest of the pipeline continues to use the reference annotation**.
+
+The merged GTF is not yet wired into the riboseq ORF callers because their nf-core modules accept only a single GTF input and have no slot for a secondary annotation. Ribo-TISH `predict` and Ribotricer can in principle scan novel transcripts for ORFs while classifying against the reference (Ribo-TISH `-a` flag, equivalent for Ribotricer), but doing so cleanly requires an upstream module update first; see the PR/issue tracker for the follow-on.
 
 <details markdown="1">
 <summary>Output files</summary>

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -306,6 +306,18 @@ By default, the input GTF file will be filtered to ensure that sequence names co
 
 The pipeline will by default run the [Ribo-TISH](https://github.com/zhpn1024/ribotish) [quality](https://github.com/zhpn1024/ribotish?tab=readme-ov-file#quality) and [predict](https://github.com/zhpn1024/ribotish?tab=readme-ov-file#predict) commands for QC and ORF prediction, respectively. Additional arguments can be supplied to either command via the `--extra_ribotish_quality_args` and `--extra_ribotish_predict_args` parameters.
 
+## Novel transcript discovery (StringTie)
+
+By default the pipeline relies entirely on the supplied GTF for transcript definitions. For studies of unannotated or non-canonical ORFs (micro-proteins, novel uORFs/dORFs), set `--skip_stringtie false` to enable [StringTie](https://ccb.jhu.edu/software/stringtie/) reference-guided assembly. The pipeline runs StringTie per sample using the input GTF as a guide, then merges per-sample assemblies into a unified annotation with `stringtie --merge`.
+
+When enabled, the merged GTF replaces the reference annotation for the genome-BAM-side ORF callers (Ribo-TISH, Ribotricer), the plastid metagene step, and the in-frame p-site quantification. RiboCode, riboWaltz, and alignment-mode Salmon stay on the reference annotation because their transcriptome BAMs were keyed to it at STAR alignment time.
+
+Trade-offs:
+
+- Adds one StringTie run per sample plus a merge step. The merge step is fast; per-sample StringTie runtime scales with library depth.
+- The merged GTF can be tightened with `--extra_stringtie_merge_args` (e.g. `'-T 1 -f 0.1'` for stricter TPM and isoform-fraction cutoffs); see the [StringTie manual](https://ccb.jhu.edu/software/stringtie/index.shtml?t=manual) for the full set of merge flags.
+- Per-sample StringTie args can be customised with `--extra_stringtie_args`.
+
 ## P-site identification
 
 The pipeline will by default run [riboWaltz](https://github.com/LabTranslationalArchitectomics/riboWaltz) for P-site identification and diagnostics, unless disabled with `--skip_ribowaltz`. Additional arguments can be supplied via `--extra_ribowaltz_args` parameters. An example is: `--extra_ribowaltz_args "--length_range 27:31 --periodicity_threshold 40 --extremity 5end --start_nts 45 --stop_nts 24"`. If not provided, defaults used in the [nf-core module](https://github.com/nf-core/modules/blob/master/modules/nf-core/ribowaltz/templates/ribowaltz.r) are used.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -308,15 +308,14 @@ The pipeline will by default run the [Ribo-TISH](https://github.com/zhpn1024/rib
 
 ## Novel transcript discovery (StringTie)
 
-By default the pipeline relies entirely on the supplied GTF for transcript definitions. For studies of unannotated or non-canonical ORFs (micro-proteins, novel uORFs/dORFs), set `--skip_stringtie false` to enable [StringTie](https://ccb.jhu.edu/software/stringtie/) reference-guided assembly. The pipeline runs StringTie per sample using the input GTF as a guide, then merges per-sample assemblies into a unified annotation with `stringtie --merge`.
+Set `--skip_stringtie false` to enable [StringTie](https://ccb.jhu.edu/software/stringtie/) reference-guided assembly. The pipeline runs StringTie per sample using the input GTF as a guide, then merges per-sample assemblies into a unified annotation with `stringtie --merge`. The merged GTF is published under `<outdir>/stringtie/stringtie_merge.gtf` for users to consume downstream.
 
-When enabled, the merged GTF replaces the reference annotation for the genome-BAM-side ORF callers (Ribo-TISH, Ribotricer), the plastid metagene step, and the in-frame p-site quantification. RiboCode, riboWaltz, and alignment-mode Salmon stay on the reference annotation because their transcriptome BAMs were keyed to it at STAR alignment time.
+In this initial PR the merged GTF is **not yet routed back into the riboseq ORF callers** - the rest of the pipeline still runs against the supplied reference GTF. Wiring Ribo-TISH `predict` and Ribotricer to use the merged GTF for novel-ORF discovery (with the reference GTF as a secondary annotation for classification) is the planned follow-on; it depends on an upstream nf-core/modules update to expose a secondary-annotation argument on those modules.
 
-Trade-offs:
+Knobs:
 
-- Adds one StringTie run per sample plus a merge step. The merge step is fast; per-sample StringTie runtime scales with library depth.
-- The merged GTF can be tightened with `--extra_stringtie_merge_args` (e.g. `'-T 1 -f 0.1'` for stricter TPM and isoform-fraction cutoffs); see the [StringTie manual](https://ccb.jhu.edu/software/stringtie/index.shtml?t=manual) for the full set of merge flags.
-- Per-sample StringTie args can be customised with `--extra_stringtie_args`.
+- `--extra_stringtie_args` - extra args passed to per-sample StringTie.
+- `--extra_stringtie_merge_args` - extra args passed to `stringtie --merge` (e.g. `'-T 1 -f 0.1'` for stricter TPM and isoform-fraction cutoffs); see the [StringTie manual](https://ccb.jhu.edu/software/stringtie/index.shtml?t=manual) for the full set of merge flags.
 
 ## P-site identification
 

--- a/modules.json
+++ b/modules.json
@@ -254,6 +254,16 @@
                         "git_sha": "481efe07277c76e23738b4be0724ba7d99653d7e",
                         "installed_by": ["modules"]
                     },
+                    "stringtie/merge": {
+                        "branch": "master",
+                        "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
+                        "installed_by": ["bam_stringtie_merge"]
+                    },
+                    "stringtie/stringtie": {
+                        "branch": "master",
+                        "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
+                        "installed_by": ["bam_stringtie_merge"]
+                    },
                     "summarizedexperiment/summarizedexperiment": {
                         "branch": "master",
                         "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
@@ -331,6 +341,11 @@
                             "bam_dedup_stats_samtools_umitools",
                             "bam_sort_stats_samtools"
                         ]
+                    },
+                    "bam_stringtie_merge": {
+                        "branch": "master",
+                        "git_sha": "2fc6aef2691483864904e31973ccafd2ed68fd56",
+                        "installed_by": ["subworkflows"]
                     },
                     "fastq_align_star": {
                         "branch": "master",

--- a/modules/nf-core/stringtie/merge/environment.yml
+++ b/modules/nf-core/stringtie/merge/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bioconda::stringtie=2.2.1

--- a/modules/nf-core/stringtie/merge/main.nf
+++ b/modules/nf-core/stringtie/merge/main.nf
@@ -1,0 +1,41 @@
+process STRINGTIE_MERGE {
+    tag "${meta.id}"
+    label 'process_medium'
+
+    // Note: 2.7X indices incompatible with AWS iGenomes.
+    conda "${moduleDir}/environment.yml"
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://depot.galaxyproject.org/singularity/stringtie:2.2.1--hecb563c_2'
+        : 'quay.io/biocontainers/stringtie:2.2.1--hecb563c_2'}"
+
+    input:
+    tuple val(meta), path(gtf)
+    tuple val(meta2), path(annotation_gtf)
+
+    output:
+    tuple val(meta), path("${prefix}.gtf"), emit: merged_gtf
+    tuple val("${task.process}"), val('stringtie'), eval('stringtie --version'), emit: versions_stringtie, topic: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    prefix = task.ext.prefix ?: "${meta.id}"
+    def reference = annotation_gtf ? "-G ${annotation_gtf}" : ""
+    """
+    stringtie \\
+        --merge \\
+        ${gtf} \\
+        ${reference} \\
+        -o ${prefix}.gtf \\
+        -p ${task.cpus} \\
+        ${args}
+    """
+
+    stub:
+    prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}.gtf
+    """
+}

--- a/modules/nf-core/stringtie/merge/meta.yml
+++ b/modules/nf-core/stringtie/merge/meta.yml
@@ -1,0 +1,80 @@
+name: stringtie_merge
+description: Merges the annotation gtf file and the stringtie output gtf files
+keywords:
+  - merge
+  - gtf
+  - reference
+tools:
+  - stringtie2:
+      description: |
+        Transcript assembly and quantification for RNA-Seq
+      homepage: https://ccb.jhu.edu/software/stringtie/index.shtml
+      documentation: https://ccb.jhu.edu/software/stringtie/index.shtml?t=manual
+      licence:
+        - "MIT"
+      identifier: biotools:stringtie
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:false ]
+    - gtf:
+        type: file
+        description: |
+          Stringtie transcript gtf output(s) to be merged together.
+        pattern: "*.{gtf|gff}"
+        ontologies:
+          - edam: "http://edamontology.org/format_2306"
+          - edam: "http://edamontology.org/format_1975"
+  - - meta2:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:false ]
+    - annotation_gtf:
+        type: file
+        description: |
+          Reference annotation gtf file (optional).
+        pattern: "*.{gtf}"
+        ontologies:
+          - edam: "http://edamontology.org/format_2306"
+output:
+  versions_stringtie:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - stringtie:
+          type: string
+          description: The name of the tool
+      - stringtie --version:
+          type: eval
+          description: The expression to obtain the version of the tool
+  merged_gtf:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - ${prefix}.gtf:
+          type: file
+          description: A unified non-redundant set of isoforms from the provided
+            gtf files.
+          pattern: "${prefix}.{gtf}"
+          ontologies:
+            - edam: "http://edamontology.org/format_2306"
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - stringtie:
+          type: string
+          description: The name of the tool
+      - stringtie --version:
+          type: eval
+          description: The expression to obtain the version of the tool
+authors:
+  - "@yuukiiwa"
+maintainers:
+  - "@yuukiiwa"

--- a/modules/nf-core/stringtie/merge/tests/main.nf.test
+++ b/modules/nf-core/stringtie/merge/tests/main.nf.test
@@ -1,0 +1,68 @@
+nextflow_process {
+
+    name "Test Process STRINGTIE_MERGE"
+    script "../main.nf"
+    process "STRINGTIE_MERGE"
+    tag "modules"
+    tag "modules_nfcore"
+    tag "stringtie"
+    tag "stringtie/merge"
+    tag "stringtie/stringtie"
+
+    setup {
+        run("STRINGTIE_STRINGTIE") {
+            script "../../stringtie/main.nf"
+            process {
+            """
+            input[0] = [
+                        [ id:'test', strandedness:'reverse' ], // meta map
+                        [ file(params.modules_testdata_base_path + "genomics/homo_sapiens/illumina/bam/test.paired_end.sorted.bam", checkIfExists: true) ]
+                        ]
+            input[1] = file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.gtf', checkIfExists: true)
+            """
+            }
+        }
+    }
+
+    test("homo_sapiens - forward strandedness") {
+
+        when {
+            process {
+                """
+                input[0] = STRINGTIE_STRINGTIE.out.transcript_gtf
+                input[1] = [[id:'ref', strandedness:'forward'], file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.gtf', checkIfExists: true) ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+            { assert process.success },
+            { assert snapshot(
+                sanitizeOutput(process.out)
+                ).match() }
+            )
+        }
+    }
+
+    test("homo_sapiens - reverse strandedness") {
+
+        when {
+            process {
+                """
+                input[0] = STRINGTIE_STRINGTIE.out.transcript_gtf
+                input[1] = [[id:'ref', strandedness:'reverse'], file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.gtf', checkIfExists: true) ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+            { assert process.success },
+            { assert snapshot(
+                sanitizeOutput(process.out)
+                ).match() }
+            )
+        }
+    }
+}

--- a/modules/nf-core/stringtie/merge/tests/main.nf.test.snap
+++ b/modules/nf-core/stringtie/merge/tests/main.nf.test.snap
@@ -1,0 +1,56 @@
+{
+    "homo_sapiens - forward strandedness": {
+        "content": [
+            {
+                "merged_gtf": [
+                    [
+                        {
+                            "id": "test",
+                            "strandedness": "reverse"
+                        },
+                        "test.gtf:md5,40780dc05eff7cf2c77705f857768441"
+                    ]
+                ],
+                "versions_stringtie": [
+                    [
+                        "STRINGTIE_MERGE",
+                        "stringtie",
+                        "2.2.1"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-04-08T13:02:20.089324763",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    },
+    "homo_sapiens - reverse strandedness": {
+        "content": [
+            {
+                "merged_gtf": [
+                    [
+                        {
+                            "id": "test",
+                            "strandedness": "reverse"
+                        },
+                        "test.gtf:md5,40780dc05eff7cf2c77705f857768441"
+                    ]
+                ],
+                "versions_stringtie": [
+                    [
+                        "STRINGTIE_MERGE",
+                        "stringtie",
+                        "2.2.1"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-04-08T13:02:52.305961798",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    }
+}

--- a/modules/nf-core/stringtie/stringtie/environment.yml
+++ b/modules/nf-core/stringtie/stringtie/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bioconda::stringtie=2.2.3

--- a/modules/nf-core/stringtie/stringtie/main.nf
+++ b/modules/nf-core/stringtie/stringtie/main.nf
@@ -1,0 +1,58 @@
+process STRINGTIE_STRINGTIE {
+    tag "$meta.id"
+    label 'process_medium'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/stringtie:2.2.3--h43eeafb_0' :
+        'quay.io/biocontainers/stringtie:2.2.3--h43eeafb_0' }"
+
+    input:
+    tuple val(meta), path(bam)
+    path  annotation_gtf
+
+    output:
+    tuple val(meta), path("*.transcripts.gtf"), emit: transcript_gtf
+    tuple val(meta), path("*.abundance.txt")  , emit: abundance
+    tuple val(meta), path("*.coverage.gtf")   , optional: true, emit: coverage_gtf
+    tuple val(meta), path("*.ballgown")       , optional: true, emit: ballgown
+    tuple val("${task.process}"), val('stringtie'), eval("stringtie --version"), emit: versions_stringtie, topic: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args      = task.ext.args ?: ''
+    def prefix    = task.ext.prefix ?: "${meta.id}"
+    def reference = annotation_gtf ? "-G $annotation_gtf" : ""
+    def ballgown  = annotation_gtf ? "-b ${prefix}.ballgown" : ""
+    def coverage  = annotation_gtf ? "-C ${prefix}.coverage.gtf" : ""
+
+    def strandedness = ''
+    if (meta.strandedness == 'forward') {
+        strandedness = '--fr'
+    } else if (meta.strandedness == 'reverse') {
+        strandedness = '--rf'
+    }
+    """
+    stringtie \\
+        $bam \\
+        $strandedness \\
+        $reference \\
+        -o ${prefix}.transcripts.gtf \\
+        -A ${prefix}.gene.abundance.txt \\
+        $coverage \\
+        $ballgown \\
+        -p $task.cpus \\
+        $args
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}.transcripts.gtf
+    touch ${prefix}.gene.abundance.txt
+    touch ${prefix}.coverage.gtf
+    touch ${prefix}.ballgown
+    """
+}

--- a/modules/nf-core/stringtie/stringtie/meta.yml
+++ b/modules/nf-core/stringtie/stringtie/meta.yml
@@ -1,0 +1,103 @@
+name: stringtie_stringtie
+description: Transcript assembly and quantification for RNA-Se
+keywords:
+  - transcript
+  - assembly
+  - quantification
+  - gtf
+tools:
+  - stringtie2:
+      description: |
+        Transcript assembly and quantification for RNA-Seq
+      homepage: https://ccb.jhu.edu/software/stringtie/index.shtml
+      documentation: https://ccb.jhu.edu/software/stringtie/index.shtml?t=manual
+      licence: ["MIT"]
+      identifier: biotools:stringtie
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:false ]
+    - bam:
+        type: file
+        description: |
+          Stringtie transcript gtf output(s).
+        ontologies: []
+  - annotation_gtf:
+      type: file
+      description: |
+        Annotation gtf file (optional).
+      ontologies: []
+output:
+  transcript_gtf:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.transcripts.gtf":
+          type: file
+          description: transcript gtf
+          pattern: "*.{transcripts.gtf}"
+          ontologies: []
+  abundance:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.abundance.txt":
+          type: file
+          description: abundance
+          pattern: "*.{abundance.txt}"
+          ontologies: []
+  coverage_gtf:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.coverage.gtf":
+          type: file
+          description: coverage gtf
+          pattern: "*.{coverage.gtf}"
+          ontologies: []
+  ballgown:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.ballgown":
+          type: file
+          description: for running ballgown
+          pattern: "*.{ballgown}"
+          ontologies: []
+  versions_stringtie:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - stringtie:
+          type: string
+          description: The name of the tool
+      - "stringtie --version":
+          type: eval
+          description: The expression to obtain the version of the tool
+
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - stringtie:
+          type: string
+          description: The name of the tool
+      - "stringtie --version":
+          type: eval
+          description: The expression to obtain the version of the tool
+
+authors:
+  - "@drpatelh"
+maintainers:
+  - "@drpatelh"

--- a/modules/nf-core/stringtie/stringtie/tests/main.nf.test
+++ b/modules/nf-core/stringtie/stringtie/tests/main.nf.test
@@ -1,0 +1,213 @@
+nextflow_process {
+
+    name "Test Process STRINGTIE_STRINGTIE"
+    script "../main.nf"
+    process "STRINGTIE_STRINGTIE"
+    config "./nextflow.config"
+    tag "modules"
+    tag "modules_nfcore"
+    tag "stringtie"
+    tag "stringtie/stringtie"
+
+    test("sarscov2 [bam] - forward strandedness") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                            [ id:'test', strandedness:'forward' ], // meta map
+                            [ file(params.modules_testdata_base_path + "genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam", checkIfExists: true) ]
+                        ]
+                input[1] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    process.out.abundance,
+                    process.out.transcript_gtf,
+                    process.out.findAll { key, val -> key.startsWith('versions') }
+                ).match() }
+            )
+        }
+    }
+
+    test("sarscov2 [bam] - forward strandedness + reference annotation") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', strandedness:'forward' ], // meta map
+                    [ file(params.modules_testdata_base_path + "genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam", checkIfExists: true) ]
+                ]
+                input[1] = file(params.modules_testdata_base_path + "genomics/sarscov2/genome/genome.gtf", checkIfExists: true)
+                """
+            }
+        }
+
+        then {
+            assertAll(
+            { assert process.success },
+                { assert snapshot(
+                    process.out.abundance,
+                    process.out.ballgown,
+                    process.out.transcript_gtf,
+                    process.out.findAll { key, val -> key.startsWith('versions') }
+                ).match() }
+            )
+        }
+    }
+
+    test("sarscov2 [bam] - reverse strandedness") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                            [ id:'test', strandedness:'reverse' ], // meta map
+                            [ file(params.modules_testdata_base_path + "genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam", checkIfExists: true) ]
+                        ]
+                input[1] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    process.out.abundance,
+                    process.out.transcript_gtf,
+                    process.out.findAll { key, val -> key.startsWith('versions') }
+                ).match() }
+            )
+        }
+    }
+
+    test("sarscov2 [bam] - reverse strandedness + reference annotation") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                            [ id:'test', strandedness:'reverse' ], // meta map
+                            [ file(params.modules_testdata_base_path + "genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam", checkIfExists: true) ]
+                        ]
+                input[1] = file(params.modules_testdata_base_path + "genomics/sarscov2/genome/genome.gtf", checkIfExists: true)
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    process.out.abundance,
+                    process.out.ballgown,
+                    process.out.transcript_gtf,
+                    process.out.findAll { key, val -> key.startsWith('versions') }
+                ).match() }
+            )
+        }
+    }
+
+    test("sarscov2 [bam] - forward strandedness - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                            [ id:'test', strandedness:'forward' ], // meta map
+                            [ file(params.modules_testdata_base_path + "genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam", checkIfExists: true) ]
+                        ]
+                input[1] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("sarscov2 [bam] - forward strandedness + reference annotation - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', strandedness:'forward' ], // meta map
+                    [ file(params.modules_testdata_base_path + "genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam", checkIfExists: true) ]
+                ]
+                input[1] = file(params.modules_testdata_base_path + "genomics/sarscov2/genome/genome.gtf", checkIfExists: true)
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("sarscov2 [bam] - reverse strandedness - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                            [ id:'test', strandedness:'reverse' ], // meta map
+                            [ file(params.modules_testdata_base_path + "genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam", checkIfExists: true) ]
+                        ]
+                input[1] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("sarscov2 [bam] - reverse strandedness + reference annotation - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                            [ id:'test', strandedness:'reverse' ], // meta map
+                            [ file(params.modules_testdata_base_path + "genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam", checkIfExists: true) ]
+                        ]
+                input[1] = file(params.modules_testdata_base_path + "genomics/sarscov2/genome/genome.gtf", checkIfExists: true)
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+}

--- a/modules/nf-core/stringtie/stringtie/tests/main.nf.test.snap
+++ b/modules/nf-core/stringtie/stringtie/tests/main.nf.test.snap
@@ -1,0 +1,564 @@
+{
+    "sarscov2 [bam] - forward strandedness + reference annotation": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "strandedness": "forward"
+                    },
+                    "test.gene.abundance.txt:md5,7d8bce7f2a922e367cedccae7267c22e"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "strandedness": "forward"
+                    },
+                    [
+                        "e2t.ctab:md5,e981c0038295ae54b63cedb1083f1540",
+                        "e_data.ctab:md5,6b4cf69bc03f3f69890f972a0e8b7471",
+                        "i2t.ctab:md5,8a117c8aa4334b4c2d4711932b006fb4",
+                        "i_data.ctab:md5,be3abe09740603213f83d50dcf81427f",
+                        "t_data.ctab:md5,3b66c065da73ae0dd41cc332eff6a818"
+                    ]
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "strandedness": "forward"
+                    },
+                    "test.transcripts.gtf:md5,37154e7bda96544f24506ee902bb561d"
+                ]
+            ],
+            {
+                "versions_stringtie": [
+                    [
+                        "STRINGTIE_STRINGTIE",
+                        "stringtie",
+                        "2.2.3"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.3"
+        },
+        "timestamp": "2026-02-02T16:30:11.16528789"
+    },
+    "sarscov2 [bam] - forward strandedness": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "strandedness": "forward"
+                    },
+                    "test.gene.abundance.txt:md5,d6f5c8cadb8458f1df0427cf790246e3"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "strandedness": "forward"
+                    },
+                    "test.transcripts.gtf:md5,6087dfc9700a52d9e4a1ae3fcd1d1dfd"
+                ]
+            ],
+            {
+                "versions_stringtie": [
+                    [
+                        "STRINGTIE_STRINGTIE",
+                        "stringtie",
+                        "2.2.3"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.3"
+        },
+        "timestamp": "2026-02-02T16:30:05.908980074"
+    },
+    "sarscov2 [bam] - forward strandedness - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "strandedness": "forward"
+                        },
+                        "test.transcripts.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test",
+                            "strandedness": "forward"
+                        },
+                        "test.gene.abundance.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test",
+                            "strandedness": "forward"
+                        },
+                        "test.coverage.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "3": [
+                    [
+                        {
+                            "id": "test",
+                            "strandedness": "forward"
+                        },
+                        "test.ballgown:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "4": [
+                    [
+                        "STRINGTIE_STRINGTIE",
+                        "stringtie",
+                        "2.2.3"
+                    ]
+                ],
+                "abundance": [
+                    [
+                        {
+                            "id": "test",
+                            "strandedness": "forward"
+                        },
+                        "test.gene.abundance.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "ballgown": [
+                    [
+                        {
+                            "id": "test",
+                            "strandedness": "forward"
+                        },
+                        "test.ballgown:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "coverage_gtf": [
+                    [
+                        {
+                            "id": "test",
+                            "strandedness": "forward"
+                        },
+                        "test.coverage.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "transcript_gtf": [
+                    [
+                        {
+                            "id": "test",
+                            "strandedness": "forward"
+                        },
+                        "test.transcripts.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_stringtie": [
+                    [
+                        "STRINGTIE_STRINGTIE",
+                        "stringtie",
+                        "2.2.3"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.3"
+        },
+        "timestamp": "2026-02-02T16:30:26.94909715"
+    },
+    "sarscov2 [bam] - forward strandedness + reference annotation - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "strandedness": "forward"
+                        },
+                        "test.transcripts.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test",
+                            "strandedness": "forward"
+                        },
+                        "test.gene.abundance.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test",
+                            "strandedness": "forward"
+                        },
+                        "test.coverage.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "3": [
+                    [
+                        {
+                            "id": "test",
+                            "strandedness": "forward"
+                        },
+                        "test.ballgown:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "4": [
+                    [
+                        "STRINGTIE_STRINGTIE",
+                        "stringtie",
+                        "2.2.3"
+                    ]
+                ],
+                "abundance": [
+                    [
+                        {
+                            "id": "test",
+                            "strandedness": "forward"
+                        },
+                        "test.gene.abundance.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "ballgown": [
+                    [
+                        {
+                            "id": "test",
+                            "strandedness": "forward"
+                        },
+                        "test.ballgown:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "coverage_gtf": [
+                    [
+                        {
+                            "id": "test",
+                            "strandedness": "forward"
+                        },
+                        "test.coverage.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "transcript_gtf": [
+                    [
+                        {
+                            "id": "test",
+                            "strandedness": "forward"
+                        },
+                        "test.transcripts.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_stringtie": [
+                    [
+                        "STRINGTIE_STRINGTIE",
+                        "stringtie",
+                        "2.2.3"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.3"
+        },
+        "timestamp": "2026-02-02T16:30:32.157264403"
+    },
+    "sarscov2 [bam] - reverse strandedness + reference annotation - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "strandedness": "reverse"
+                        },
+                        "test.transcripts.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test",
+                            "strandedness": "reverse"
+                        },
+                        "test.gene.abundance.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test",
+                            "strandedness": "reverse"
+                        },
+                        "test.coverage.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "3": [
+                    [
+                        {
+                            "id": "test",
+                            "strandedness": "reverse"
+                        },
+                        "test.ballgown:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "4": [
+                    [
+                        "STRINGTIE_STRINGTIE",
+                        "stringtie",
+                        "2.2.3"
+                    ]
+                ],
+                "abundance": [
+                    [
+                        {
+                            "id": "test",
+                            "strandedness": "reverse"
+                        },
+                        "test.gene.abundance.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "ballgown": [
+                    [
+                        {
+                            "id": "test",
+                            "strandedness": "reverse"
+                        },
+                        "test.ballgown:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "coverage_gtf": [
+                    [
+                        {
+                            "id": "test",
+                            "strandedness": "reverse"
+                        },
+                        "test.coverage.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "transcript_gtf": [
+                    [
+                        {
+                            "id": "test",
+                            "strandedness": "reverse"
+                        },
+                        "test.transcripts.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_stringtie": [
+                    [
+                        "STRINGTIE_STRINGTIE",
+                        "stringtie",
+                        "2.2.3"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.3"
+        },
+        "timestamp": "2026-02-02T16:30:42.741125528"
+    },
+    "sarscov2 [bam] - reverse strandedness - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "strandedness": "reverse"
+                        },
+                        "test.transcripts.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test",
+                            "strandedness": "reverse"
+                        },
+                        "test.gene.abundance.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test",
+                            "strandedness": "reverse"
+                        },
+                        "test.coverage.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "3": [
+                    [
+                        {
+                            "id": "test",
+                            "strandedness": "reverse"
+                        },
+                        "test.ballgown:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "4": [
+                    [
+                        "STRINGTIE_STRINGTIE",
+                        "stringtie",
+                        "2.2.3"
+                    ]
+                ],
+                "abundance": [
+                    [
+                        {
+                            "id": "test",
+                            "strandedness": "reverse"
+                        },
+                        "test.gene.abundance.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "ballgown": [
+                    [
+                        {
+                            "id": "test",
+                            "strandedness": "reverse"
+                        },
+                        "test.ballgown:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "coverage_gtf": [
+                    [
+                        {
+                            "id": "test",
+                            "strandedness": "reverse"
+                        },
+                        "test.coverage.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "transcript_gtf": [
+                    [
+                        {
+                            "id": "test",
+                            "strandedness": "reverse"
+                        },
+                        "test.transcripts.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_stringtie": [
+                    [
+                        "STRINGTIE_STRINGTIE",
+                        "stringtie",
+                        "2.2.3"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.3"
+        },
+        "timestamp": "2026-02-02T16:30:37.444482002"
+    },
+    "sarscov2 [bam] - reverse strandedness + reference annotation": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "strandedness": "reverse"
+                    },
+                    "test.gene.abundance.txt:md5,7385b870b955dae2c2ab78a70cf05cce"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "strandedness": "reverse"
+                    },
+                    [
+                        "e2t.ctab:md5,e981c0038295ae54b63cedb1083f1540",
+                        "e_data.ctab:md5,879b6696029d19c4737b562e9d149218",
+                        "i2t.ctab:md5,8a117c8aa4334b4c2d4711932b006fb4",
+                        "i_data.ctab:md5,be3abe09740603213f83d50dcf81427f",
+                        "t_data.ctab:md5,3b66c065da73ae0dd41cc332eff6a818"
+                    ]
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "strandedness": "reverse"
+                    },
+                    "test.transcripts.gtf:md5,fbabb4e3888bbede67f11f692e484880"
+                ]
+            ],
+            {
+                "versions_stringtie": [
+                    [
+                        "STRINGTIE_STRINGTIE",
+                        "stringtie",
+                        "2.2.3"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.3"
+        },
+        "timestamp": "2026-02-02T16:30:21.762442003"
+    },
+    "sarscov2 [bam] - reverse strandedness": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "strandedness": "reverse"
+                    },
+                    "test.gene.abundance.txt:md5,d6f5c8cadb8458f1df0427cf790246e3"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "strandedness": "reverse"
+                    },
+                    "test.transcripts.gtf:md5,01d6da00a3c458420841e57427297183"
+                ]
+            ],
+            {
+                "versions_stringtie": [
+                    [
+                        "STRINGTIE_STRINGTIE",
+                        "stringtie",
+                        "2.2.3"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.3"
+        },
+        "timestamp": "2026-02-02T16:30:16.466823767"
+    }
+}

--- a/modules/nf-core/stringtie/stringtie/tests/nextflow.config
+++ b/modules/nf-core/stringtie/stringtie/tests/nextflow.config
@@ -1,0 +1,5 @@
+process {
+    withName: 'STRINGTIE_STRINGTIE' {
+        ext.args = ''
+    }
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -122,6 +122,11 @@ params {
     extra_plastid_psite_args             = null
     extra_plastid_make_wiggle_args       = null
 
+    // StringTie novel transcript discovery
+    skip_stringtie                       = true
+    extra_stringtie_args                 = null
+    extra_stringtie_merge_args           = null
+
 
     // Read length equalisation
     equalise_read_lengths             = false

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -485,6 +485,14 @@
                     "type": "string",
                     "description": "Extra arguments to pass to the riboWaltz command in addition to defaults defined by the pipeline."
                 },
+                "extra_stringtie_args": {
+                    "type": "string",
+                    "description": "Extra arguments to pass to per-sample StringTie in addition to defaults defined by the pipeline."
+                },
+                "extra_stringtie_merge_args": {
+                    "type": "string",
+                    "description": "Extra arguments to pass to StringTie --merge (e.g. `-T 1 -f 0.1` to tighten the merged annotation)."
+                },
                 "extra_anota2seq_run_args": {
                     "type": "string",
                     "description": "Extra arguments to pass to anota2seq in addition to defaults defined by the pipeline. Available options include: --gene_id_col (column name for gene IDs in count table, default: 'gene_id'), --exclude_samples_col and --exclude_samples_values (exclude samples by column value, semicolon-separated). Note: --samples_pairing_col and --samples_batch_col are automatically set from the 'pair' and 'batch' columns in the contrast file if present."
@@ -714,6 +722,13 @@
                 "skip_plastid": {
                     "type": "boolean",
                     "description": "Skip plastid.",
+                    "fa_icon": "fas fa-fast-forward"
+                },
+                "skip_stringtie": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Skip StringTie reference-guided transcript assembly and merge.",
+                    "help_text": "When `false`, the pipeline runs StringTie per sample (reference-guided) then merges per-sample GTFs into a unified annotation. The merged GTF is consumed by the genome-BAM-side ORF callers (Ribo-TISH, Ribotricer, plastid) and by the in-frame p-site quantification step. RiboCode, riboWaltz, and alignment-mode Salmon stay on the reference annotation because their transcriptome BAMs are keyed to it.",
                     "fa_icon": "fas fa-fast-forward"
                 }
             }

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -728,7 +728,7 @@
                     "type": "boolean",
                     "default": true,
                     "description": "Skip StringTie reference-guided transcript assembly and merge.",
-                    "help_text": "When `false`, the pipeline runs StringTie per sample (reference-guided) then merges per-sample GTFs into a unified annotation. The merged GTF is consumed by the genome-BAM-side ORF callers (Ribo-TISH, Ribotricer, plastid) and by the in-frame p-site quantification step. RiboCode, riboWaltz, and alignment-mode Salmon stay on the reference annotation because their transcriptome BAMs are keyed to it.",
+                    "help_text": "When `false`, the pipeline runs StringTie per sample (reference-guided) then merges per-sample GTFs into a unified annotation. The merged GTF is published under `<outdir>/stringtie/stringtie_merge.gtf` as a side product. The downstream ORF callers continue to consume the supplied reference GTF in this version; routing the merged GTF into Ribo-TISH `predict` / Ribotricer is the planned follow-on once their nf-core modules expose a secondary-annotation argument.",
                     "fa_icon": "fas fa-fast-forward"
                 }
             }

--- a/subworkflows/nf-core/bam_stringtie_merge/main.nf
+++ b/subworkflows/nf-core/bam_stringtie_merge/main.nf
@@ -1,0 +1,30 @@
+include { STRINGTIE_STRINGTIE } from '../../../modules/nf-core/stringtie/stringtie/main'
+include { STRINGTIE_MERGE     } from '../../../modules/nf-core/stringtie/merge/main'
+
+
+workflow BAM_STRINGTIE_MERGE {
+    take:
+    bam_sorted // channel: [ meta, bam ]
+    ch_chrgtf // channel: [ meta, gtf ]
+
+    main:
+
+    STRINGTIE_STRINGTIE(
+        bam_sorted,
+        ch_chrgtf.map { _meta, gtf -> [gtf] },
+    )
+
+    STRINGTIE_STRINGTIE.out.transcript_gtf
+        .map { _meta, gtf -> gtf }
+        .toSortedList { a, b -> a.name <=> b.name }
+        .map { gtfs -> [ [id: 'stringtie_merge'], gtfs ] }
+        .set { collected_gtfs }
+
+    STRINGTIE_MERGE(
+        collected_gtfs,
+        ch_chrgtf
+    )
+
+    emit:
+    stringtie_gtf = STRINGTIE_MERGE.out.merged_gtf // channel: [ meta, gtf ]
+}

--- a/subworkflows/nf-core/bam_stringtie_merge/meta.yml
+++ b/subworkflows/nf-core/bam_stringtie_merge/meta.yml
@@ -1,0 +1,48 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/subworkflows/yaml-schema.json
+name: "bam_stringtie_merge"
+description: >
+  Assemble transcripts from sorted BAM alignments using StringTie, then merge
+  per-sample transcript GTFs into a unified annotation.
+keywords:
+  - rna-seq
+  - transcript-assembly
+  - transcript-merge
+  - stringtie
+  - gtf
+components:
+  - stringtie/stringtie
+  - stringtie/merge
+input:
+  - bam_sorted:
+      type: file
+      description: |
+        Sorted alignment files.
+        Structure: [ val(meta), path(bam) ]
+      pattern: "*.bam"
+  - ch_chrgtf:
+      type: file
+      description: |
+        Reference gene annotation (GTF) for guided assembly and merge.
+        Structure: [ val(meta), path(gtf) ]
+      pattern: "*.gtf"
+output:
+  - stringtie_gtf:
+      type: file
+      description: |
+        Merged transcript annotation produced by StringTie --merge.
+        Structure: [ val(meta), path(gtf) ]
+      pattern: "*.gtf"
+  - versions:
+      type: file
+      description: |
+        File containing software versions for the subworkflow components.
+        Structure: [ path(versions.yml) ]
+      pattern: "versions.yml"
+authors:
+  - "@atrigila"
+  - "@rannick"
+  - "@nvnieuwk"
+maintainers:
+  - "@atrigila"
+  - "@rannick"
+  - "@nvnieuwk"

--- a/subworkflows/nf-core/bam_stringtie_merge/tests/main.nf.test
+++ b/subworkflows/nf-core/bam_stringtie_merge/tests/main.nf.test
@@ -1,0 +1,47 @@
+nextflow_workflow {
+
+    name "Test BAM_STRINGTIE_MERGE"
+    script "../main.nf"
+    workflow "BAM_STRINGTIE_MERGE"
+    tag "subworkflows"
+    tag "subworkflows_nfcore"
+    tag "stringtie"
+    tag "stringtie/stringtie"
+    tag "stringtie/merge"
+    tag "subworkflows/bam_stringtie_merge"
+
+    test("Should merge transcripts across multiple samples") {
+
+        when {
+            workflow {
+                """
+                input[0] = Channel.of(
+                    [
+                        [ id:'sample1', strandedness:'reverse' ],
+                        file(params.modules_testdata_base_path + "genomics/homo_sapiens/illumina/bam/test.paired_end.sorted.bam", checkIfExists: true)
+                    ],
+                    [
+                        [ id:'sample2', strandedness:'reverse' ],
+                        file(params.modules_testdata_base_path + "genomics/homo_sapiens/illumina/bam/test.paired_end.sorted.bam", checkIfExists: true)
+                    ]
+                )
+                input[1] = Channel.value([
+                    [ id:'annotation' ],
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/genome/genome.gtf", checkIfExists: true)
+                ])
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+                { assert workflow.out.stringtie_gtf.size() == 1 },
+                { assert snapshot(
+                    sanitizeOutput(workflow.out)
+                    ).match() },
+            )
+        }
+    }
+
+}

--- a/subworkflows/nf-core/bam_stringtie_merge/tests/main.nf.test.snap
+++ b/subworkflows/nf-core/bam_stringtie_merge/tests/main.nf.test.snap
@@ -1,0 +1,21 @@
+{
+    "Should merge transcripts across multiple samples": {
+        "content": [
+            {
+                "stringtie_gtf": [
+                    [
+                        {
+                            "id": "stringtie_merge"
+                        },
+                        "stringtie_merge.gtf:md5,3d11d4f54395709b4fdca53ea31cea7e"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-04-14T13:36:54.066473"
+    }
+}

--- a/workflows/riboseq/main.nf
+++ b/workflows/riboseq/main.nf
@@ -292,18 +292,16 @@ workflow RIBOSEQ {
 
     //
     // SUBWORKFLOW: Reference-guided novel transcript discovery with StringTie.
-    // The merged GTF is fed to genome-BAM-side ORF callers (Ribo-TISH, Ribotricer,
-    // plastid) and to GTF-only steps. Transcriptome-BAM-bound tools (RiboCode,
-    // riboWaltz, alignment-mode Salmon) stay on the reference annotation because
-    // their BAMs were keyed to it at STAR time.
+    // The merged GTF is published as a side product. Wiring it back into the
+    // ORF callers needs upstream nf-core/modules updates to expose a secondary
+    // annotation arg (Ribo-TISH `-a`, equivalent for Ribotricer); see #157
+    // and the PR description for the planned follow-on.
     //
-    ch_gtf_for_genome_tools = ch_gtf
     if (!params.skip_stringtie) {
         BAM_STRINGTIE_MERGE(
             ch_genome_bam,
             ch_gtf.map { gtf -> [ [:], gtf ] }
         )
-        ch_gtf_for_genome_tools = BAM_STRINGTIE_MERGE.out.stringtie_gtf.map { _meta, gtf -> gtf }
     }
 
     //
@@ -367,12 +365,12 @@ workflow RIBOSEQ {
         }
 
     ch_bams_for_analysis = ch_genome_bam_by_type.riboseq.join(ch_genome_bam_index)
-    ch_fasta_gtf = ch_fasta.combine(ch_gtf_for_genome_tools).map{ fasta, gtf -> [ [:], fasta, gtf ] }.first()
+    ch_fasta_gtf = ch_fasta.combine(ch_gtf).map{ fasta, gtf -> [ [:], fasta, gtf ] }.first()
 
     if (!params.skip_ribotish){
         RIBOTISH_QUALITY_RIBOSEQ(
             ch_bams_for_analysis,
-            ch_gtf_for_genome_tools.map { [ [:], it ] }.first()
+            ch_gtf.map { [ [:], it ] }.first()
         )
         ch_versions      = ch_versions.mix(RIBOTISH_QUALITY_RIBOSEQ.out.versions)
         ch_multiqc_files = ch_multiqc_files.mix(RIBOTISH_QUALITY_RIBOSEQ.out.distribution.collect{it[1]})
@@ -484,7 +482,7 @@ workflow RIBOSEQ {
 
     if (!params.skip_plastid) {
 
-        PLASTID_METAGENE_GENERATE(ch_gtf_for_genome_tools.map { [ [:], it ] })
+        PLASTID_METAGENE_GENERATE(ch_gtf.map { [ [:], it ] })
         ch_versions = ch_versions.mix(PLASTID_METAGENE_GENERATE.out.versions)
 
         PLASTID_PSITE(
@@ -556,7 +554,7 @@ workflow RIBOSEQ {
     if (params.te_quantification_method == 'plastid_psite' && !params.skip_plastid) {
         // Convert GTF CDS segments to in-frame p-site positions
         GTF_TO_INFRAME_PSITES(
-            ch_gtf_for_genome_tools.map { gtf -> [ [id: gtf.baseName, feature: 'gene'], gtf ] },
+            ch_gtf.map { gtf -> [ [id: gtf.baseName, feature: 'gene'], gtf ] },
             file("${projectDir}/bin/gtf_to_inframe_psites.awk"),
             false
         )

--- a/workflows/riboseq/main.nf
+++ b/workflows/riboseq/main.nf
@@ -9,8 +9,9 @@
 //
 include { FASTQ_QC_TRIM_FILTER_SETSTRANDEDNESS                                                 } from '../../subworkflows/nf-core/fastq_qc_trim_filter_setstrandedness/main'
 include { FASTQ_EQUALISE_READ_LENGTHS                                                          } from '../../subworkflows/local/fastq_equalise_read_lengths'
-include { BAM_DEDUP_UMI      } from '../../subworkflows/nf-core/bam_dedup_umi'
-include { FASTQ_ALIGN_STAR   } from '../../subworkflows/nf-core/fastq_align_star'
+include { BAM_DEDUP_UMI       } from '../../subworkflows/nf-core/bam_dedup_umi'
+include { FASTQ_ALIGN_STAR    } from '../../subworkflows/nf-core/fastq_align_star'
+include { BAM_STRINGTIE_MERGE } from '../../subworkflows/nf-core/bam_stringtie_merge'
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -290,6 +291,22 @@ workflow RIBOSEQ {
     }
 
     //
+    // SUBWORKFLOW: Reference-guided novel transcript discovery with StringTie.
+    // The merged GTF is fed to genome-BAM-side ORF callers (Ribo-TISH, Ribotricer,
+    // plastid) and to GTF-only steps. Transcriptome-BAM-bound tools (RiboCode,
+    // riboWaltz, alignment-mode Salmon) stay on the reference annotation because
+    // their BAMs were keyed to it at STAR time.
+    //
+    ch_gtf_for_genome_tools = ch_gtf
+    if (!params.skip_stringtie) {
+        BAM_STRINGTIE_MERGE(
+            ch_genome_bam,
+            ch_gtf.map { gtf -> [ [:], gtf ] }
+        )
+        ch_gtf_for_genome_tools = BAM_STRINGTIE_MERGE.out.stringtie_gtf.map { _meta, gtf -> gtf }
+    }
+
+    //
     // Generate coverage tracks
     //
 
@@ -350,12 +367,12 @@ workflow RIBOSEQ {
         }
 
     ch_bams_for_analysis = ch_genome_bam_by_type.riboseq.join(ch_genome_bam_index)
-    ch_fasta_gtf = ch_fasta.combine(ch_gtf).map{ fasta, gtf -> [ [:], fasta, gtf ] }.first()
+    ch_fasta_gtf = ch_fasta.combine(ch_gtf_for_genome_tools).map{ fasta, gtf -> [ [:], fasta, gtf ] }.first()
 
     if (!params.skip_ribotish){
         RIBOTISH_QUALITY_RIBOSEQ(
             ch_bams_for_analysis,
-            ch_gtf.map { [ [:], it ] }.first()
+            ch_gtf_for_genome_tools.map { [ [:], it ] }.first()
         )
         ch_versions      = ch_versions.mix(RIBOTISH_QUALITY_RIBOSEQ.out.versions)
         ch_multiqc_files = ch_multiqc_files.mix(RIBOTISH_QUALITY_RIBOSEQ.out.distribution.collect{it[1]})
@@ -467,7 +484,7 @@ workflow RIBOSEQ {
 
     if (!params.skip_plastid) {
 
-        PLASTID_METAGENE_GENERATE(ch_gtf.map { [ [:], it ] })
+        PLASTID_METAGENE_GENERATE(ch_gtf_for_genome_tools.map { [ [:], it ] })
         ch_versions = ch_versions.mix(PLASTID_METAGENE_GENERATE.out.versions)
 
         PLASTID_PSITE(
@@ -539,7 +556,7 @@ workflow RIBOSEQ {
     if (params.te_quantification_method == 'plastid_psite' && !params.skip_plastid) {
         // Convert GTF CDS segments to in-frame p-site positions
         GTF_TO_INFRAME_PSITES(
-            ch_gtf.map { gtf -> [ [id: gtf.baseName, feature: 'gene'], gtf ] },
+            ch_gtf_for_genome_tools.map { gtf -> [ [id: gtf.baseName, feature: 'gene'], gtf ] },
             file("${projectDir}/bin/gtf_to_inframe_psites.awk"),
             false
         )


### PR DESCRIPTION
Closes #157.

## Summary

- Install `nf-core/bam_stringtie_merge` subworkflow plus `stringtie/stringtie` (2.2.3) and `stringtie/merge` (2.2.1) modules.
- Add `--skip_stringtie` (default `true` - inverted vs. rnaseq, novel-ORF discovery is a power-user workflow), `--extra_stringtie_args`, `--extra_stringtie_merge_args`.
- Publish the merged GTF as a side product under `<outdir>/stringtie/stringtie_merge.gtf` plus per-sample `<id>.denovo.transcripts.gtf` assemblies.
- The rest of the pipeline continues to consume the supplied reference GTF. **The merged GTF is not yet wired back into Ribo-TISH / Ribotricer / plastid / GTF_TO_INFRAME_PSITES** - see "Decisions" below.

## Required follow-on nf-core/modules changes

Wiring the merged GTF into the riboseq ORF callers needs upstream module updates first. Concrete asks (file as separate PRs against [nf-core/modules](https://github.com/nf-core/modules)):

- [ ] **`ribotish/predict`** - add an optional `tuple val(meta), path(alt_gtf)` input that maps to `-a` on the CLI. This is the classification annotation Ribo-TISH uses to tag ORFs as `uORF` / `dORF` / `annotated` / `CDSFrameOverlap` / `Novel`. Without it, every ORF found on the merged GTF would be tagged generically.
- [ ] **`ribotish/quality`** - same shape (optional secondary GTF -> `-a`). Less critical (quality currently runs on reference and stays there), but worth aligning so a future "all-merged-GTF" mode is consistent.
- [ ] **`ribotricer/prepareorfs`** - investigate whether the upstream Ribotricer CLI has an equivalent secondary-annotation flag for ORF classification (`prepare-orfs --annotation`?). If yes, add an optional input. If no, file an upstream Ribotricer feature request.

Once those modules expose secondary annotation, the riboseq-side follow-on PR is small: bump the modules, change the affected call sites in `workflows/riboseq/main.nf` to pass `merged_gtf` as primary and `reference_gtf` as secondary, and the merged GTF starts informing novel-ORF discovery.

Plastid and `GTF_TO_INFRAME_PSITES` stay on the reference GTF regardless - they're CDS-bound for ROI definition / read filtering and there isn't a sensible "secondary annotation" semantics for them.

## Decisions to revisit

These were debated in this PR's iteration; capturing them so we can revisit if context shifts.

### 1. Merged GTF is published only, not consumed by ORF callers - for now

**Why:** the riboseq ORF callers split into two correctness regimes:

- CDS-aware tools (Ribo-TISH `quality`, plastid metagene, `GTF_TO_INFRAME_PSITES`) need reference CDS for read filtering or ROI definition. StringTie's merged GTF only emits `transcript` and `exon` features, no `CDS`. Feeding the merged GTF here gives `Counted reads: 0. Error: no reads found! Check protein coding annotation.` (verified on the VM at `0c5e02bf` before this revert).
- De novo ORF scanners (Ribo-TISH `predict`, Ribotricer `prepare-orfs`, RiboCode) **can** scan a CDS-less GTF for ORFs - that's how they work. But to *classify* discovered ORFs (uORF / dORF / annotated / `CDSFrameOverlap` / Novel) they need the reference CDS as a secondary annotation. Ribo-TISH's CLI exposes `-a SECONDARY` for exactly this case.

**Blocker:** the nf-core modules `ribotish/quality`, `ribotish/predict`, and `ribotricer/prepareorfs` all take a single GTF input - no slot for a secondary annotation. See the "Required follow-on" checklist above.

**Plan:** land this PR as side-product-only; the follow-on lands the proper wiring once the modules are updated.

### 2. Transcriptome-BAM-bound tools are intentionally excluded

RiboCode, riboWaltz, and alignment-mode Salmon all consume STAR's transcriptome BAM, which was keyed to the reference GTF at alignment time. Swapping in a different GTF post-hoc would create a transcript-ID mismatch. A future opt-in (`stringtie_realign` or similar) could rebuild the Salmon index and re-run STAR with the merged GTF; out of scope for this PR.

### 3. TransDecoder pre-pass for sequence-level CDS prediction on novel transcripts

Considered and rejected for now. The Ribo-seq ORF callers do their own ORF scanning + filtering on transcripts using Ribo-seq evidence (triplet periodicity, P-site coverage). A TransDecoder pre-pass would add a sequence-level filter (Markov ORF score, BLAST, Pfam) that's biased differently - it could discard short or unusual ORFs that Ribo-seq evidence would have validated. The Ribo-seq tools' built-in scanners are the right discovery layer; TransDecoder would only matter as a side artefact for proteomics/orthogonal validation.

If we want sequence-level ORF prediction as a separate output, it should be a distinct opt-in flag with its own deliverable, not coupled to the main StringTie wiring.

### 4. `-e` is intentionally absent from the per-sample StringTie call

`-e` restricts StringTie's output to transcripts already in the reference GTF, which would silently make the merged GTF a clone of the reference and turn the whole feature into a no-op. Mirrors the fix in nf-core/rnaseq commit `9a0835e`.

### 5. CLI ergonomics caveat

`--skip_stringtie false` from the CLI is rejected by the nf-schema plugin as a string when the schema default is `true`. Users need to override via `-c <config>` or `-params-file`. This is an nf-schema behaviour (also affects other `default: true` boolean params in the pipeline), not specific to this PR.

## Implementation notes

- The per-sample StringTie call inside the subworkflow uses `-v` only.
- The subworkflow-internal `STRINGTIE_STRINGTIE` is matched by a process selector scoped to `NFCORE_RIBOSEQ:RIBOSEQ:BAM_STRINGTIE_MERGE:STRINGTIE_STRINGTIE` and emits `<id>.denovo.transcripts.gtf`. Per-sample abundance/coverage outputs are not published (not comparable across samples pre-merge).
- Schema entries split: `skip_stringtie` is in the skip-* group; `extra_stringtie_*_args` are in the extra-args group with the rest of the per-tool extras.

## Test plan

- [x] `nf-core pipelines schema lint` clean.
- [x] `nf-core pipelines lint` - 0 failures.
- [x] `nextflow inspect` resolves `STRINGTIE_STRINGTIE` and `STRINGTIE_MERGE` containers when StringTie is on.
- [x] **VM end-to-end with `--skip_stringtie false`**: pipeline completed in 10m 17s, 359 tasks succeeded. Per-sample `*.denovo.transcripts.gtf` published for all 12 samples; merged `stringtie_merge.gtf` published (8.7 MB, 52,032 `MSTRG` records). All downstream consumers (Ribo-TISH quality + predict, riboWaltz, plastid metagene/psite/wiggle, Salmon, anota2seq, MultiQC) ran cleanly against the unchanged reference GTF.
- [ ] CI on this push.