### PR TITLE
fix: make plastid_psite the default --te_quantification_method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#152](https://github.com/nf-core/riboseq/pull/152) - Update ribodetector module to 0.3.3 (nf-core/modules#11131) ([@pinin4fjords](https://github.com/pinin4fjords))
 - [#154](https://github.com/nf-core/riboseq/pull/154) - Update nf-core/multiqc module to 1.34 ([@pinin4fjords](https://github.com/pinin4fjords))
 - [#154](https://github.com/nf-core/riboseq/pull/154) - Align FastQC/SortMeRNA general-stats handling with `nf-core/rnaseq` ([@pinin4fjords](https://github.com/pinin4fjords))
+- [#160](https://github.com/nf-core/riboseq/issues/160) - **Breaking default change:** flip the default `--te_quantification_method` from `alignment` (STAR + Salmon) to `plastid_psite` (in-frame P-site counts from plastid). Salmon's coverage-uniformity, fragment-length and multi-mapping assumptions are inappropriate for short, length-constrained Ribo-seq footprints; in-frame P-site counts are the scientifically correct quantity. The two methods produce fundamentally different per-gene count values (Salmon TPM-derived pseudo-counts vs raw integer in-frame P-site sums), so re-running an existing cohort on a newer pipeline version with the default will not reproduce the previous count matrix. Users who need backward-compatible Salmon-style counts must now set `--te_quantification_method alignment` explicitly. ([@pinin4fjords](https://github.com/pinin4fjords))
 
 ### `Parameters`
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -368,13 +368,30 @@ Both methods require the same input format and contrasts specification, but prod
 
 The pipeline offers three methods for quantifying gene expression for TE analysis, controlled by the `--te_quantification_method` parameter:
 
-#### Alignment-based (default)
+#### In-frame P-sites (default)
+
+```bash
+--te_quantification_method plastid_psite
+```
+
+This is the default method. RNA-seq reads are quantified using the alignment-based method (STAR + Salmon). Ribo-seq reads are counted only if they map to coding regions and their predicted P-sites (as determined by Plastid) coincide with the annotated reading frame. Specifically, a Ribo-seq read is counted only when its inferred P-site aligns with the reading frame of a coding sequence (CDS) defined in the provided annotation (GTF) file.
+
+This is the scientifically appropriate quantity for Ribo-seq. Salmon's underlying model assumes uniform coverage and a length-dependent fragment distribution and relies on long or paired-end reads to resolve multi-mapping. Ribo-seq footprints (~28-32 nt) violate all three assumptions: coverage non-uniformity is the biological signal, fragment lengths are physically constrained by the ribosome, and short footprints cannot disambiguate shared exons (see [Ribomap, Bioinformatics 2016](https://academic.oup.com/bioinformatics/article/32/12/1880/1744291)).
+
+Caveats:
+
+- The methods used to quantify RNA-seq reads and Ribo-seq reads are not the same, giving rise to different technical biases in the counts.
+- The quantification of in-frame P-sites is subject to the periodicity of the Ribo-seq experiment. Before comparing samples against each other, it should be confirmed that the periodicities of the samples are similar.
+- Quantification of overlapping ORFs is still flawed and cannot be fully deconvoluted, since the counts from one ORF can leak into the other ORF unless the periodicity efficiency is perfect (which it usually is not).
+- Counts are summed per gene; ORF-level quantification is not yet supported in this mode.
+
+#### Alignment-based
 
 ```bash
 --te_quantification_method alignment
 ```
 
-This is the default method. Reads are aligned with STAR, and Salmon quantifies from the transcriptome BAM in alignment-based mode. This approach leverages full alignment information and is suitable for most analyses.
+Reads are aligned with STAR, and Salmon quantifies from the transcriptome BAM in alignment-based mode. This was the default in earlier pipeline versions and is retained for backward compatibility and for downstream tools that expect Salmon-format transcript-level counts. Choose this if you need to reproduce results from a prior run, compare against a Salmon-based cohort, or feed counts into a tool that specifically expects Salmon output. Note that switching from `alignment` to `plastid_psite` (or vice versa) changes the actual per-gene count values - downstream comparisons across pipeline versions are not apples-to-apples if the default changed between runs.
 
 #### Pseudo-alignment
 
@@ -394,22 +411,6 @@ Consider this option when:
 - You prefer k-mer-based quantification for methodological consistency between modalities
 
 > **Note**: The pseudo-alignment pathway runs **in addition to** the standard STAR alignment, which is still needed for position-dependent analyses (P-sites, ribosome periodicity, ORF detection). The pseudo-alignment counts are only used for TE analysis.
-
-#### In-frame P-sites
-
-```bash
---te_quantification_method plastid_psite
-```
-
-In this mode, RNA‑seq reads are quantified using the default alignment‑based method. Ribo‑seq reads, however, are counted only if they map to coding regions and their predicted P‑sites (as determined by Plastid) coincide with the annotated reading frame. This **experimental mode** applies conservative filters to Ribo‑seq quantification. Specifically, a Ribo‑seq read is counted only when its inferred P‑site aligns with the reading frame of a coding sequence (CDS) defined in the provided annotation (GTF) file.
-
-Consider using this option when you want to quantify on the level of ORFs rather than transcripts. This is particularly relevant in cases where a transcript has multiple ORFs, but you want to focus on annotated ones rather than summing up the counts from all ORFs of the transcript.
-
-Note that this method comes with potential caveats:
-
-- The methods used to quantify RNA-seq reads and Ribo-seq reads are not the same, giving rise to different technical biases in the counts.
-- The quantification of in-frame P-sites is subject to the periodicity of the Ribo-seq experiment. Before comparing samples against each other, it should be confirmed that the periodicities of the samples are similar.
-- Although this method counts only in-frame P-sites, quantification of overlapping ORFs is still flawed and cannot be fully deconvoluted, since the counts from one ORF can leak into the other ORF unless the periodicity efficiency is perfect (which it usually is not).
 
 ### Contrasts specification
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -128,7 +128,7 @@ params {
     equalise_read_lengths_target      = null
 
     // TE quantification method
-    te_quantification_method          = 'alignment'
+    te_quantification_method          = 'plastid_psite'
 
     // MultiQC options
     multiqc_config             = null

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -561,10 +561,10 @@
                 },
                 "te_quantification_method": {
                     "type": "string",
-                    "default": "alignment",
+                    "default": "plastid_psite",
                     "enum": ["alignment", "pseudo", "plastid_psite"],
-                    "description": "Quantification method for translational efficiency analysis: 'alignment' (STAR → Salmon), 'pseudo' (Salmon pseudo-alignment) or 'plastid_psite' (in-frame p-site counts from plastid).",
-                    "help_text": "Choose 'alignment' for STAR alignment followed by Salmon in alignment-based mode (default). Choose 'pseudo' for direct Salmon pseudo-alignment, an experimental alternative that uses the same k-mer index for both modalities and may help reduce length-related quantification biases without requiring read trimming. Choose 'plastid_psite' to replace Ribo-seq counts with the sum of in-frame p-site counts per gene as determined by plastid (experimental). Only p-sites that fall on in-frame codon positions within CDS segments are counted.",
+                    "description": "Quantification method for translational efficiency analysis: 'plastid_psite' (in-frame P-site counts from plastid, default), 'alignment' (STAR -> Salmon) or 'pseudo' (Salmon pseudo-alignment).",
+                    "help_text": "Default is 'plastid_psite': Ribo-seq reads are counted only when their inferred P-site coincides with an in-frame codon position in an annotated CDS (derived from plastid wiggle tracks). This is the scientifically appropriate quantity for Ribo-seq, because Salmon's underlying assumptions (uniform coverage, fragment-length distribution, multi-mapping resolution from longer/paired reads) are violated by short, length-constrained Ribo-seq footprints (see Ribomap, Bioinformatics 2016). Choose 'alignment' to keep STAR alignment followed by Salmon in alignment-based mode, e.g. for backward compatibility, comparison with prior runs, or downstream tools that expect Salmon-format transcript-level counts. Choose 'pseudo' for direct Salmon pseudo-alignment from reads, an experimental alternative that uses the same k-mer index for both modalities and may help reduce length-related quantification biases without requiring read trimming.",
                     "fa_icon": "fas fa-calculator"
                 }
             }


### PR DESCRIPTION
## Summary

Flip the default for `--te_quantification_method` from `alignment` (STAR -> Salmon) to `plastid_psite` (in-frame P-site counts from plastid wiggle tracks).

Salmon was designed for RNA-seq. Its coverage, fragment-length, and multi-mapping assumptions are violated by short (~28-32 nt), length-constrained Ribo-seq footprints (Ribomap, Bioinformatics 2016). In-frame P-site counts are the scientifically appropriate quantity for Ribo-seq translational efficiency analysis.

## Changes

- `nextflow.config` + `nextflow_schema.json`: default flipped to `plastid_psite`, all three modes (`alignment`, `pseudo`, `plastid_psite`) retained.
- `docs/usage.md`: explain when `alignment` mode is still appropriate (backward comparison, downstream tooling that expects Salmon-format output).
- `CHANGELOG.md`: marked as breaking default change.

Per-gene count values from a re-run on the new default will not match prior `alignment`-mode runs. Existing pipelines that need the old behaviour set `--te_quantification_method alignment`.

## Stacked PR notes

First in a stack splitting #174 into per-issue PRs. Targets `dev`. Subsequent PRs in the stack will target this branch.

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)