### PR TITLE
Give CUSTOM_ORFMERGE enough memory and wall-clock at genome scale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#207](https://github.com/nf-core/riboseq/pull/207) - Resolve ORF catalogue gene ids against the union of the full multi-isoform annotation and the novel transcripts instead of the canonical backbone, so ORFs called on non-representative isoforms (PRICE and Rp-Bp are handed the full annotation by design) keep a gene id that joins against the ORF-level DTE RNA denominator ([@pinin4fjords](https://github.com/pinin4fjords))
 - [#209](https://github.com/nf-core/riboseq/pull/209) - Give Rp-Bp and PRICE the full reference with the novel intergenic genes appended under `--extended_orf_analysis`, so both bring novel transcripts into scope without collapsing to the one-transcript-per-gene backbone the hybrid GTF is built on ([@pinin4fjords](https://github.com/pinin4fjords))
 - [#217](https://github.com/nf-core/riboseq/pull/217) - Re-pin `gedi/indexgenome` and `gedi/price` (nf-core/modules#12451) so the GEDI index carries its FASTA and the `.oml`'s absolute paths are repointed at read time, fixing `--run_price` failing in PRICE's `PriceCodonInference` where the path GEDI recorded for the staged input was never materialised ([@FelixKrueger](https://github.com/FelixKrueger), [@pinin4fjords](https://github.com/pinin4fjords))
+- [#229](https://github.com/nf-core/riboseq/pull/229) - Raise `CUSTOM_ORFMERGE` memory and wall-clock so a genome-scale cohort merge completes on its first attempt ([@FelixKrueger](https://github.com/FelixKrueger))
 
 ### `Removed`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#207](https://github.com/nf-core/riboseq/pull/207) - Resolve ORF catalogue gene ids against the union of the full multi-isoform annotation and the novel transcripts instead of the canonical backbone, so ORFs called on non-representative isoforms (PRICE and Rp-Bp are handed the full annotation by design) keep a gene id that joins against the ORF-level DTE RNA denominator ([@pinin4fjords](https://github.com/pinin4fjords))
 - [#209](https://github.com/nf-core/riboseq/pull/209) - Give Rp-Bp and PRICE the full reference with the novel intergenic genes appended under `--extended_orf_analysis`, so both bring novel transcripts into scope without collapsing to the one-transcript-per-gene backbone the hybrid GTF is built on ([@pinin4fjords](https://github.com/pinin4fjords))
 - [#217](https://github.com/nf-core/riboseq/pull/217) - Re-pin `gedi/indexgenome` and `gedi/price` (nf-core/modules#12451) so the GEDI index carries its FASTA and the `.oml`'s absolute paths are repointed at read time, fixing `--run_price` failing in PRICE's `PriceCodonInference` where the path GEDI recorded for the staged input was never materialised ([@FelixKrueger](https://github.com/FelixKrueger), [@pinin4fjords](https://github.com/pinin4fjords))
-- [#229](https://github.com/nf-core/riboseq/pull/229) - Raise `CUSTOM_ORFMERGE` memory and wall-clock so a genome-scale cohort merge completes on its first attempt ([@FelixKrueger](https://github.com/FelixKrueger))
+- [#229](https://github.com/nf-core/riboseq/pull/229) - Raise `CUSTOM_ORFMERGE`'s wall-clock limit so a genome-scale cohort merge completes on its first attempt ([@FelixKrueger](https://github.com/FelixKrueger))
 
 ### `Removed`
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -1108,9 +1108,8 @@ process {
     }
     withName: '.*:ORFTABLE_FASTA_GTF_BUILDORFCATALOGUE:CUSTOM_ORFMERGE' {
         ext.args   = { "--min-callers ${params.orf_min_callers} --min-samples ${params.orf_min_samples}" }
-        // Complete-linkage clustering, ~15h and over 72 GB at genome scale; first-attempt headroom.
-        memory     = { 108.GB * task.attempt }
-        time       = { 30.h   * task.attempt }
+        // Cohort merge takes ~15h at genome scale; first-attempt headroom.
+        time       = { 30.h * task.attempt }
         // The published consensus is the merger's only when the collapse is
         // skipped; otherwise CUSTOM_ORFCOLLAPSE publishes the post-collapse one.
         publishDir = params.skip_orf_collapse ? [

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -1108,6 +1108,9 @@ process {
     }
     withName: '.*:ORFTABLE_FASTA_GTF_BUILDORFCATALOGUE:CUSTOM_ORFMERGE' {
         ext.args   = { "--min-callers ${params.orf_min_callers} --min-samples ${params.orf_min_samples}" }
+        // Complete-linkage clustering, ~15h and over 72 GB at genome scale; first-attempt headroom.
+        memory     = { 108.GB * task.attempt }
+        time       = { 30.h   * task.attempt }
         // The published consensus is the merger's only when the collapse is
         // skipped; otherwise CUSTOM_ORFCOLLAPSE publishes the post-collapse one.
         publishDir = params.skip_orf_collapse ? [


### PR DESCRIPTION
`CUSTOM_ORFMERGE` does not fit `process_medium` on a genome-scale cohort. On an 18-sample, 4-caller run it was killed at 36 GB/8h and again at 72 GB/16h before completing in 14h42m at 108 GB — about 39 hours of wall-clock to do 15 hours of work. This sets `memory` and `time` on the selector that already governs the process, and leaves `cpus` on the label because `orfmerge.py` is single-threaded. Resource directives are not part of a task's cache key, so this is safe to apply to a running session with `-resume`.

<details>
<summary>Detail (AI-assisted)</summary>

- Both kills report exit 143 with an empty `.command.err`, which reads as OOM. The durations matching `8.h * task.attempt` to the second are what identify the wall-clock limit as the terminator instead.
- `time` is generous (30h, matching the `RPBP_ESTIMATE*BAYESFACTORS` override in the same file) because it is a ceiling billed on actual runtime, whereas `memory` is a reservation and stays at the measured 108 GB.
- `process_high` would be the wrong reflex here: its first attempt is 72 GB/16h, exactly the configuration that already failed.
- Attempt 3 succeeded in less time than attempt 2 was allowed, so the extra memory bought speed rather than only headroom.
- Cache-neutrality checked on a live resume rather than argued: 3123 of 3123 banked tasks still cached with the change applied.

</details>
