### PR TITLE
Pin DESEQ2_DELTATE_ORF's cpus at genome scale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#217](https://github.com/nf-core/riboseq/pull/217) - Re-pin `gedi/indexgenome` and `gedi/price` (nf-core/modules#12451) so the GEDI index carries its FASTA and the `.oml`'s absolute paths are repointed at read time, fixing `--run_price` failing in PRICE's `PriceCodonInference` where the path GEDI recorded for the staged input was never materialised ([@FelixKrueger](https://github.com/FelixKrueger), [@pinin4fjords](https://github.com/pinin4fjords))
 - [#228](https://github.com/nf-core/riboseq/pull/228) - Let the `nf-test` workflow report `confirm-pass` on docs-only PRs, which previously left them permanently blocked ([@FelixKrueger](https://github.com/FelixKrueger))
 - [#229](https://github.com/nf-core/riboseq/pull/229) - Raise `CUSTOM_ORFMERGE`'s wall-clock limit so a genome-scale cohort merge completes on its first attempt ([@FelixKrueger](https://github.com/FelixKrueger))
+- [#230](https://github.com/nf-core/riboseq/pull/230) - Raise `DESEQ2_DELTATE_ORF`'s wall-clock limit so genome-scale ORF-level deltaTE contrasts complete on their first attempt ([@FelixKrueger](https://github.com/FelixKrueger))
 
 ### `Removed`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#217](https://github.com/nf-core/riboseq/pull/217) - Re-pin `gedi/indexgenome` and `gedi/price` (nf-core/modules#12451) so the GEDI index carries its FASTA and the `.oml`'s absolute paths are repointed at read time, fixing `--run_price` failing in PRICE's `PriceCodonInference` where the path GEDI recorded for the staged input was never materialised ([@FelixKrueger](https://github.com/FelixKrueger), [@pinin4fjords](https://github.com/pinin4fjords))
 - [#228](https://github.com/nf-core/riboseq/pull/228) - Let the `nf-test` workflow report `confirm-pass` on docs-only PRs, which previously left them permanently blocked ([@FelixKrueger](https://github.com/FelixKrueger))
 - [#229](https://github.com/nf-core/riboseq/pull/229) - Raise `CUSTOM_ORFMERGE`'s wall-clock limit so a genome-scale cohort merge completes on its first attempt ([@FelixKrueger](https://github.com/FelixKrueger))
-- [#230](https://github.com/nf-core/riboseq/pull/230) - Raise `DESEQ2_DELTATE_ORF`'s wall-clock limit so genome-scale ORF-level deltaTE contrasts complete on their first attempt ([@FelixKrueger](https://github.com/FelixKrueger))
+- [#230](https://github.com/nf-core/riboseq/pull/230) - Pin `DESEQ2_DELTATE_ORF`'s cpus and raise its wall-clock limit so genome-scale ORF-level deltaTE contrasts complete on their first attempt ([@FelixKrueger](https://github.com/FelixKrueger))
 
 ### `Removed`
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -1257,6 +1257,8 @@ process {
             params.rna_lfc_threshold ? "--lfc_threshold_rna ${params.rna_lfc_threshold}" : '',
             params.ribo_lfc_threshold ? "--lfc_threshold_ribo ${params.ribo_lfc_threshold}" : ''
         ].join(' ').trim() }
+        // Fitting hundreds of thousands of ORFs exceeds 8h at genome scale; first-attempt headroom.
+        time       = { 16.h * task.attempt }
         publishDir = [
             path: { "${params.outdir}/translational_efficiency/orf_level/deltate" },
             mode: params.publish_dir_mode,

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -1257,8 +1257,8 @@ process {
             params.rna_lfc_threshold ? "--lfc_threshold_rna ${params.rna_lfc_threshold}" : '',
             params.ribo_lfc_threshold ? "--lfc_threshold_ribo ${params.ribo_lfc_threshold}" : ''
         ].join(' ').trim() }
-        // Fitting hundreds of thousands of ORFs exceeds 8h at genome scale; first-attempt headroom.
-        time       = { 16.h * task.attempt }
+        // Fitting ~286k ORFs takes 6-14h at genome scale and varies with load; first-attempt headroom.
+        time       = { 24.h * task.attempt }
         publishDir = [
             path: { "${params.outdir}/translational_efficiency/orf_level/deltate" },
             mode: params.publish_dir_mode,

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -1257,7 +1257,8 @@ process {
             params.rna_lfc_threshold ? "--lfc_threshold_rna ${params.rna_lfc_threshold}" : '',
             params.ribo_lfc_threshold ? "--lfc_threshold_ribo ${params.ribo_lfc_threshold}" : ''
         ].join(' ').trim() }
-        // Fitting ~286k ORFs takes 6-14h at genome scale and varies with load; first-attempt headroom.
+        // DESeq2 forks one worker per cpu, so peak memory tracks the cpu count.
+        cpus       = 6
         time       = { 24.h * task.attempt }
         publishDir = [
             path: { "${params.outdir}/translational_efficiency/orf_level/deltate" },

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -1257,7 +1257,6 @@ process {
             params.rna_lfc_threshold ? "--lfc_threshold_rna ${params.rna_lfc_threshold}" : '',
             params.ribo_lfc_threshold ? "--lfc_threshold_ribo ${params.ribo_lfc_threshold}" : ''
         ].join(' ').trim() }
-        // DESeq2 forks one worker per cpu, so peak memory tracks the cpu count.
         cpus       = 6
         time       = { 24.h * task.attempt }
         publishDir = [


### PR DESCRIPTION
`DESEQ2_DELTATE_ORF` inherits `process_medium`, whose `cpus` scale with `task.attempt`. The module hands `task.cpus` to `MulticoreParam`, so every retry forks more DESeq2 workers, roughly tripling peak memory without finishing any sooner — on a genome-scale cohort the same seven contrasts ran in 3h 16m at 6 cpus and 13–14h at 18. This pins `cpus = 6`, the configuration that completes. `time` keeps its existing attempt scaling and `memory` is unchanged, so nothing else about the process changes.

<details>
<summary>Measurements behind the change (AI-assisted analysis)</summary>

Two genome-scale runs of the same seven contrasts over identical input (`ORF_COUNT_MATRIX` wchar 15.8 MB in both):

| cpus | realtime | peak_rss | core-hours |
|---|---|---|---|
| 6 | 3h 15–16m | 17.9–19 GB | 42.5 |
| 18 | 13h 04m – 14h 22m | 55.1–57.8 GB | 312.2 |

`peak_rss` per cpu is 3.08 GB at 6 and 3.14 GB at 18, so memory demand tracks the worker count rather than the problem size. Core-hours grew 7.3× for the same work, which isolates the parallelism overhead from any scheduling effect.

Every failure in both runs was `exit 143` at the wall-clock ceiling, never `137`, so memory was never the binding constraint. The label's 36 GB covers the measured 17.9–19 GB and gets no override.

The relevant lines are in `modules/local/deseq2/deltate/templates/deseq2_deltate.R`: `cores = as.integer('$task.cpus')`, `if (opt$cores > 1) register(MulticoreParam(opt$cores))`, and three `DESeq(..., parallel = (opt$cores > 1))` calls.

</details>
