### PR TITLE
fix: post-release-review cleanup

### DIFF
--- a/.github/workflows/nf-test.yml
+++ b/.github/workflows/nf-test.yml
@@ -21,7 +21,9 @@ env:
 jobs:
   nf-test-changes:
     name: nf-test-changes
-    runs-on: "ubuntu-latest" # temporarily using GitHub-hosted runners while self-hosted runners are down
+    runs-on: # use self-hosted runners
+      - runs-on=${{ github.run_id }}-nf-test-changes
+      - runner=4cpu-linux-x64
     outputs:
       shard: ${{ steps.set-shards.outputs.shard }}
       total_shards: ${{ steps.set-shards.outputs.total_shards }}
@@ -53,7 +55,10 @@ jobs:
     name: "${{ matrix.profile }} | ${{ matrix.NXF_VER }} | ${{ matrix.shard }}/${{ needs.nf-test-changes.outputs.total_shards }}"
     needs: [nf-test-changes]
     if: ${{ needs.nf-test-changes.outputs.total_shards != '0' }}
-    runs-on: "ubuntu-latest" # temporarily using GitHub-hosted runners while self-hosted runners are down
+    runs-on: # use self-hosted runners
+      - runs-on=${{ github.run_id }}-nf-test
+      - runner=4cpu-linux-x64
+      - volume=120g
     strategy:
       fail-fast: false
       matrix:
@@ -123,7 +128,9 @@ jobs:
   confirm-pass:
     needs: [nf-test-changes, nf-test]
     if: always()
-    runs-on: "ubuntu-latest" # temporarily using GitHub-hosted runners while self-hosted runners are down
+    runs-on: # use self-hosted runners
+      - runs-on=${{ github.run_id }}-confirm-pass
+      - runner=2cpu-linux-x64
     steps:
       - name: One or more tests failed (excluding latest-everything)
         if: ${{ contains(needs.*.result, 'failure') }}

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -103,7 +103,7 @@ process {
     }
 
     withName: 'CUSTOM_GTFFILTER' {
-        ext.args   = { params.skip_gtf_transcript_filter ?: '--skip_transcript_id_check' }
+        ext.args   = { params.skip_gtf_transcript_filter ? '--skip_transcript_id_check' : '' }
         publishDir = [
             path: { "${params.outdir}/genome" },
             mode: params.publish_dir_mode,
@@ -1072,6 +1072,7 @@ process {
     }
     withName: 'RIBOCODE_METAPLOTS' {
         ext.args   = { params.extra_ribocode_metaplots_args ?: '' }
+        errorStrategy = 'ignore'
         publishDir = [
             path: { "${params.outdir}/riboseq_qc/ribocode" },
             mode: params.publish_dir_mode,
@@ -1315,7 +1316,7 @@ process {
     withName: 'DESEQ2_DELTATE' {
         ext.args   = { [
             params.extra_deltate_args ?: '',
-            (meta.batch && meta.batch != 'null') ? "--samples_batch_col ${meta.batch}" : '',
+            (meta.batch && meta.batch != 'null') ? "--batch_col ${meta.batch}" : '',
             params.te_lfc_threshold ? "--lfc_threshold_te ${params.te_lfc_threshold}" : '',
             params.rna_lfc_threshold ? "--lfc_threshold_rna ${params.rna_lfc_threshold}" : '',
             params.ribo_lfc_threshold ? "--lfc_threshold_ribo ${params.ribo_lfc_threshold}" : ''

--- a/modules.json
+++ b/modules.json
@@ -479,7 +479,7 @@
                     },
                     "fastq_qc_trim_filter_setstrandedness": {
                         "branch": "master",
-                        "git_sha": "2e0ae2fa5d14f045f2e1360928a5d003fa5d903d",
+                        "git_sha": "0853b48c6477aa76c2d77386169a0d510ac817d6",
                         "installed_by": ["subworkflows"]
                     },
                     "fastq_remove_rrna": {
@@ -499,7 +499,7 @@
                     },
                     "orftable_fasta_gtf_buildorfcatalogue": {
                         "branch": "master",
-                        "git_sha": "be91fb1578e47bf1a8acc301bf7d755cb7313fc2",
+                        "git_sha": "7baf88e0ae1fe0e547509d7ed06aa1ed294bf13c",
                         "installed_by": ["subworkflows"]
                     },
                     "quant_tximport_summarizedexperiment": {

--- a/modules/local/deseq2/deltate/templates/deseq2_deltate.R
+++ b/modules/local/deseq2/deltate/templates/deseq2_deltate.R
@@ -376,6 +376,13 @@ sample_sheet <- sample_sheet |>
     distinct(across(all_of(opt\$sample_id_col)), .keep_all = TRUE) |>
     column_to_rownames(opt\$sample_id_col)
 
+contrast_levels <- c(opt\$reference_level, opt\$target_level)
+missing_levels <- setdiff(contrast_levels, unique(as.character(sample_sheet[[opt\$contrast_variable]])))
+if (length(missing_levels) > 0) {
+    stop(paste("Contrast level(s) not present in", opt\$contrast_variable, ":", paste(missing_levels, collapse = ", ")))
+}
+sample_sheet <- sample_sheet[as.character(sample_sheet[[opt\$contrast_variable]]) %in% contrast_levels, , drop = FALSE]
+
 missing_samples <- setdiff(rownames(sample_sheet), colnames(count_table))
 if (length(missing_samples) > 0) {
     stop(paste(length(missing_samples), "samples missing from count table"))

--- a/modules/local/deseq2/deltate/tests/main.nf.test
+++ b/modules/local/deseq2/deltate/tests/main.nf.test
@@ -68,6 +68,51 @@ nextflow_process {
         }
     }
 
+    test("human - tsv - with batch column") {
+
+        config "./nextflow_batch_col.config"
+
+        when {
+            process {
+                """
+                def samplesheet_batch = file('samplesheet_batch.csv')
+                samplesheet_batch.text = '"sample","type","treatment","pair"\\n' +
+                    '"SRX11780879","rnaseq","control",1\\n' +
+                    '"SRX11780880","rnaseq","control",2\\n' +
+                    '"SRX11780881","rnaseq","control",1\\n' +
+                    '"SRX11780882","rnaseq","treatment",2\\n' +
+                    '"SRX11780883","rnaseq","treatment",1\\n' +
+                    '"SRX11780884","rnaseq","treatment",2\\n' +
+                    '"SRX11780885","riboseq","control",1\\n' +
+                    '"SRX11780886","riboseq","control",2\\n' +
+                    '"SRX11780887","riboseq","control",1\\n' +
+                    '"SRX11780888","riboseq","treatment",2\\n' +
+                    '"SRX11780889","riboseq","treatment",1\\n' +
+                    '"SRX11780890","riboseq","treatment",2\\n'
+
+                input[0] = [
+                    [ id:'treatment_vs_control' ],
+                    'treatment',
+                    'control',
+                    'treatment'
+                ]
+                input[1] = [
+                    [ id:'test' ],
+                    samplesheet_batch,
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/riboseq_expression/salmon.merged.gene_counts_length_scaled.tsv", checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert path(process.out.dtegs[0][1]).exists() }
+            )
+        }
+    }
+
     test("human - tsv - stub") {
 
         options "-stub"

--- a/modules/local/deseq2/deltate/tests/nextflow_batch_col.config
+++ b/modules/local/deseq2/deltate/tests/nextflow_batch_col.config
@@ -1,0 +1,5 @@
+process {
+    withName: 'DESEQ2_DELTATE' {
+        ext.args = '--batch_col pair'
+    }
+}

--- a/modules/local/orf_count_matrix/main.nf
+++ b/modules/local/orf_count_matrix/main.nf
@@ -19,7 +19,7 @@ process ORF_COUNT_MATRIX {
 
     script:
     prefix = task.ext.prefix ?: "orf_psite_counts"
-    sample_ids_csv = sample_ids.join(',')
+    sample_ids_b64 = groovy.json.JsonOutput.toJson(sample_ids).bytes.encodeBase64().toString()
     template 'build_orf_count_matrix.py'
 
     stub:

--- a/modules/local/orf_count_matrix/main.nf
+++ b/modules/local/orf_count_matrix/main.nf
@@ -8,7 +8,7 @@ process ORF_COUNT_MATRIX {
         'community.wave.seqera.io/library/python_pandas_pyyaml:3ce680b21acf323f' }"
 
     input:
-    tuple val(meta), path(per_sample_counts, stageAs: 'counts/*'), path(orf_catalogue_bed12)
+    tuple val(meta), val(sample_ids), path(per_sample_counts, stageAs: 'counts/*'), path(orf_catalogue_bed12)
 
     output:
     tuple val(meta), path("*.tsv"), emit: matrix
@@ -19,6 +19,7 @@ process ORF_COUNT_MATRIX {
 
     script:
     prefix = task.ext.prefix ?: "orf_psite_counts"
+    sample_ids_csv = sample_ids.join(',')
     template 'build_orf_count_matrix.py'
 
     stub:

--- a/modules/local/orf_count_matrix/meta.yml
+++ b/modules/local/orf_count_matrix/meta.yml
@@ -23,6 +23,12 @@ input:
   - - meta:
         type: map
         description: Cohort-level metadata
+    - sample_ids:
+        type: string
+        description: |
+          Sample ids covered by `per_sample_counts`, in the same order used to build it.
+          Needed because a sample with zero in-frame P-sites produces an empty TSV with
+          no sample_id column value of its own.
     - per_sample_counts:
         type: file
         description: |

--- a/modules/local/orf_count_matrix/templates/build_orf_count_matrix.py
+++ b/modules/local/orf_count_matrix/templates/build_orf_count_matrix.py
@@ -2,10 +2,12 @@
 """Pivot per-sample ORF P-site count TSVs into a single ORF x sample matrix.
 
 Per-sample input is `sample_id<TAB>orf_id<TAB>count` (sample_id is identical
-on every row, prepended upstream by the per-sample counter). Output rows
-follow the BED12 catalogue's 4th column in catalogue order; ORFs absent
-from a sample are zero-filled, and ORFs absent from every sample still
-appear as a row of zeros so the matrix is keyed on the catalogue.
+on every row, prepended upstream by the per-sample counter); a sample with
+zero in-frame P-sites produces an empty file with no sample_id at all, so
+the expected sample list is passed in separately rather than inferred from
+the concatenated rows. Output rows follow the BED12 catalogue's 4th column
+in catalogue order, zero-filled for any ORF or sample with no matching
+counts, so the matrix is keyed on the catalogue and the full sample list.
 """
 
 import platform
@@ -22,9 +24,11 @@ catalogue_orfs = (
     pd.read_csv("$orf_catalogue_bed12", sep="\\t", header=None, comment="#", usecols=[3])[3].drop_duplicates().tolist()
 )
 
+expected_samples = sorted(s for s in "$sample_ids_csv".split(",") if s)
+
 matrix = (
     counts.pivot_table(index="orf_id", columns="sample", values="count", aggfunc="sum", fill_value=0)
-    .reindex(catalogue_orfs, fill_value=0)
+    .reindex(index=catalogue_orfs, columns=expected_samples, fill_value=0)
     .astype(int)
 )
 matrix.to_csv("${prefix}.tsv", sep="\\t")

--- a/modules/local/orf_count_matrix/templates/build_orf_count_matrix.py
+++ b/modules/local/orf_count_matrix/templates/build_orf_count_matrix.py
@@ -10,6 +10,8 @@ in catalogue order, zero-filled for any ORF or sample with no matching
 counts, so the matrix is keyed on the catalogue and the full sample list.
 """
 
+import base64
+import json
 import platform
 from pathlib import Path
 
@@ -24,7 +26,7 @@ catalogue_orfs = (
     pd.read_csv("$orf_catalogue_bed12", sep="\\t", header=None, comment="#", usecols=[3])[3].drop_duplicates().tolist()
 )
 
-expected_samples = sorted(s for s in "$sample_ids_csv".split(",") if s)
+expected_samples = sorted(json.loads(base64.b64decode("$sample_ids_b64").decode()))
 
 matrix = (
     counts.pivot_table(index="orf_id", columns="sample", values="count", aggfunc="sum", fill_value=0)

--- a/modules/local/orf_count_matrix/tests/main.nf.test
+++ b/modules/local/orf_count_matrix/tests/main.nf.test
@@ -45,4 +45,37 @@ nextflow_process {
             )
         }
     }
+
+    test("a sample id containing a comma is not corrupted") {
+        when {
+            process {
+                """
+                def sampleA_counts = file('sampleA.tsv')
+                sampleA_counts.text = "sample,A\\torf1\\t5\\n"
+
+                def sampleB_counts = file('sampleB.tsv')
+                sampleB_counts.text = "sampleB\\torf1\\t2\\n"
+
+                def catalogue_bed12 = file('catalogue.bed12')
+                catalogue_bed12.text = "chr1\\t0\\t100\\torf1\\t0\\t+\\n"
+
+                input[0] = Channel.of([
+                    [id:'allsamples'],
+                    ['sample,A', 'sampleB'],
+                    [sampleA_counts, sampleB_counts],
+                    catalogue_bed12
+                ])
+                """
+            }
+        }
+
+        then {
+            def matrix = path(process.out.matrix[0][1]).readLines()
+            assertAll(
+                { assert process.success },
+                { assert matrix[0] == 'orf_id\tsample,A\tsampleB' },
+                { assert matrix[1] == 'orf1\t5\t2' }
+            )
+        }
+    }
 }

--- a/modules/local/orf_count_matrix/tests/main.nf.test
+++ b/modules/local/orf_count_matrix/tests/main.nf.test
@@ -1,0 +1,48 @@
+nextflow_process {
+
+    name "Test Process ORF_COUNT_MATRIX"
+    script "../main.nf"
+    process "ORF_COUNT_MATRIX"
+
+    tag "modules"
+    tag "modules_local"
+    tag "orf_count_matrix"
+
+    test("one sample with zero counts is still zero-filled, not dropped") {
+        when {
+            process {
+                """
+                def sampleA_counts = file('sampleA.tsv')
+                sampleA_counts.text = "sampleA\\torf1\\t5\\nsampleA\\torf2\\t3\\n"
+
+                def sampleB_counts = file('sampleB.tsv')
+                sampleB_counts.text = ""
+
+                def catalogue_bed12 = file('catalogue.bed12')
+                catalogue_bed12.text = "chr1\\t0\\t100\\torf1\\t0\\t+\\n" +
+                    "chr1\\t100\\t200\\torf2\\t0\\t+\\n" +
+                    "chr1\\t200\\t300\\torf3\\t0\\t+\\n"
+
+                input[0] = Channel.of([
+                    [id:'allsamples'],
+                    ['sampleA', 'sampleB'],
+                    [sampleA_counts, sampleB_counts],
+                    catalogue_bed12
+                ])
+                """
+            }
+        }
+
+        then {
+            def matrix = path(process.out.matrix[0][1]).readLines()
+            assertAll(
+                { assert process.success },
+                { assert matrix[0] == 'orf_id\tsampleA\tsampleB' },
+                { assert matrix[1] == 'orf1\t5\t0' },
+                { assert matrix[2] == 'orf2\t3\t0' },
+                { assert matrix[3] == 'orf3\t0\t0' },
+                { assert snapshot(process.out.versions).match() }
+            )
+        }
+    }
+}

--- a/modules/local/orf_count_matrix/tests/main.nf.test.snap
+++ b/modules/local/orf_count_matrix/tests/main.nf.test.snap
@@ -1,0 +1,14 @@
+{
+    "one sample with zero counts is still zero-filled, not dropped": {
+        "content": [
+            [
+                "versions.yml:md5,bfb53944c4d1d212aae3385753156f2f"
+            ]
+        ],
+        "timestamp": "2026-09-06T23:33:01.247339728",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
+        }
+    }
+}

--- a/subworkflows/local/quantify_orf_psite/main.nf
+++ b/subworkflows/local/quantify_orf_psite/main.nf
@@ -46,21 +46,15 @@ workflow QUANTIFY_ORF_PSITE {
     // 3. Collect all per-sample TSVs into one list, then pair with the
     //    cohort-level catalogue BED on a synthetic key so the pairing does not
     //    depend on emission order.
-    ch_sample_ids_collected = QUANTIFY_INFRAME_PSITE_PLASTID.out.counts
-        .map { meta, _tsv -> meta.id }
-        .collect()
-        .map { ids -> [ 'allsamples', ids ] }
-
-    ch_tsvs_collected = QUANTIFY_INFRAME_PSITE_PLASTID.out.counts
-        .map { _meta, tsv -> tsv }
-        .collect()
-        .map { tsvs -> [ 'allsamples', tsvs ] }
+    ch_ids_and_tsvs_collected = QUANTIFY_INFRAME_PSITE_PLASTID.out.counts
+        .map { meta, tsv -> [ meta.id, tsv ] }
+        .collect( flat: false )
+        .map { pairs -> [ 'allsamples', pairs*.getAt(0), pairs*.getAt(1) ] }
 
     ch_bed_keyed = ch_catalogue_bed
         .map { _meta, bed -> [ 'allsamples', bed ] }
 
-    ch_matrix_in = ch_sample_ids_collected
-        .combine( ch_tsvs_collected, by: 0 )
+    ch_matrix_in = ch_ids_and_tsvs_collected
         .combine( ch_bed_keyed, by: 0 )
         .map { _key, ids, tsvs, bed -> [ [ id: 'allsamples' ], ids, tsvs, bed ] }
 

--- a/subworkflows/local/quantify_orf_psite/main.nf
+++ b/subworkflows/local/quantify_orf_psite/main.nf
@@ -46,6 +46,11 @@ workflow QUANTIFY_ORF_PSITE {
     // 3. Collect all per-sample TSVs into one list, then pair with the
     //    cohort-level catalogue BED on a synthetic key so the pairing does not
     //    depend on emission order.
+    ch_sample_ids_collected = QUANTIFY_INFRAME_PSITE_PLASTID.out.counts
+        .map { meta, _tsv -> meta.id }
+        .collect()
+        .map { ids -> [ 'allsamples', ids ] }
+
     ch_tsvs_collected = QUANTIFY_INFRAME_PSITE_PLASTID.out.counts
         .map { _meta, tsv -> tsv }
         .collect()
@@ -54,9 +59,10 @@ workflow QUANTIFY_ORF_PSITE {
     ch_bed_keyed = ch_catalogue_bed
         .map { _meta, bed -> [ 'allsamples', bed ] }
 
-    ch_matrix_in = ch_tsvs_collected
+    ch_matrix_in = ch_sample_ids_collected
+        .combine( ch_tsvs_collected, by: 0 )
         .combine( ch_bed_keyed, by: 0 )
-        .map { _key, tsvs, bed -> [ [ id: 'allsamples' ], tsvs, bed ] }
+        .map { _key, ids, tsvs, bed -> [ [ id: 'allsamples' ], ids, tsvs, bed ] }
 
     ORF_COUNT_MATRIX ( ch_matrix_in )
     ch_versions = ch_versions.mix(ORF_COUNT_MATRIX.out.versions)

--- a/subworkflows/nf-core/fastq_qc_trim_filter_setstrandedness/main.nf
+++ b/subworkflows/nf-core/fastq_qc_trim_filter_setstrandedness/main.nf
@@ -132,6 +132,7 @@ workflow FASTQ_QC_TRIM_FILTER_SETSTRANDEDNESS {
 
     ch_filtered_reads = channel.empty()
     ch_trim_read_count = channel.empty()
+    ch_trim_reads_merged = channel.empty()
     ch_multiqc_files = channel.empty()
     ch_lint_log_raw = channel.empty()
     ch_lint_log_trimmed = channel.empty()
@@ -241,6 +242,7 @@ workflow FASTQ_QC_TRIM_FILTER_SETSTRANDEDNESS {
         )
         ch_filtered_reads = FASTQ_FASTQC_UMITOOLS_FASTP.out.reads
         ch_trim_read_count = FASTQ_FASTQC_UMITOOLS_FASTP.out.trim_read_count
+        ch_trim_reads_merged = FASTQ_FASTQC_UMITOOLS_FASTP.out.trim_reads_merged
 
         // Capture individual outputs for workflow outputs
         ch_fastqc_raw_html  = FASTQ_FASTQC_UMITOOLS_FASTP.out.fastqc_raw_html
@@ -434,6 +436,7 @@ workflow FASTQ_QC_TRIM_FILTER_SETSTRANDEDNESS {
     reads_cat         = ch_reads_cat
     reads_trimmed     = ch_reads_trimmed
     trim_read_count   = ch_trim_read_count
+    trim_reads_merged = ch_trim_reads_merged
     multiqc_files     = ch_multiqc_files.transpose()
 
     // Individual outputs for workflow outputs

--- a/subworkflows/nf-core/fastq_qc_trim_filter_setstrandedness/main.nf
+++ b/subworkflows/nf-core/fastq_qc_trim_filter_setstrandedness/main.nf
@@ -156,7 +156,6 @@ workflow FASTQ_QC_TRIM_FILTER_SETSTRANDEDNESS {
     ch_ribodetector_log   = channel.empty()
     ch_seqkit_stats       = channel.empty()
     ch_bowtie2_log        = channel.empty()
-    ch_bowtie2_index      = channel.empty()
     ch_seqkit_prefixed    = channel.empty()
     ch_seqkit_converted   = channel.empty()
     ch_fastqc_filtered_html = channel.empty()
@@ -382,10 +381,10 @@ workflow FASTQ_QC_TRIM_FILTER_SETSTRANDEDNESS {
     // SUBWORKFLOW: Sub-sample FastQ files and pseudoalign with Salmon to auto-infer strandedness
     //
     // Return empty channel if ch_strand_fastq.auto_strand is empty so salmon index isn't created
-
     ch_fasta
+        .map { fasta -> [fasta] }
         .combine(ch_strand_fastq.auto_strand)
-        .map { items -> items.first() }
+        .map { items -> items[0] }
         .first()
         .set { ch_genome_fasta }
 

--- a/subworkflows/nf-core/fastq_qc_trim_filter_setstrandedness/meta.yml
+++ b/subworkflows/nf-core/fastq_qc_trim_filter_setstrandedness/meta.yml
@@ -213,6 +213,19 @@ output:
         - count:
             type: integer
             description: Number of reads after trimming
+  - trim_reads_merged:
+      description: |
+        fastp's merged overlapping read pairs, produced only when `trimmer == 'fastp'` and
+        `fastp_merge == true`. Empty otherwise. These reads are excluded from `reads`;
+        callers that want to use them downstream must consume this channel separately.
+      structure:
+        - meta:
+            type: map
+            description: Metadata for the merged reads
+        - reads:
+            type: file
+            description: fastp merged FastQ file
+            pattern: "*.merged.fastq.gz"
   - lint_log:
       description: Log files from FastQ linting
       structure:

--- a/subworkflows/nf-core/fastq_qc_trim_filter_setstrandedness/meta.yml
+++ b/subworkflows/nf-core/fastq_qc_trim_filter_setstrandedness/meta.yml
@@ -18,92 +18,67 @@ components:
   - fastq_fastqc_umitools_fastp
 input:
   - ch_reads:
-      description: Channel with input FastQ files
-      structure:
-        - meta:
-            type: map
-            description: Groovy Map containing sample information e.g. [ id:'test' ]
-        - reads:
-            type: file
-            description: FastQ files
-            pattern: "*.{fq,fastq},{,.gz}"
+      type: file
+      description: |
+        Channel with input FastQ files. The meta map contains sample information,
+        e.g. [ id:'test' ].
+
+        Structure: [ val(meta), [ path(reads) ] ]
+      pattern: "*.{fq,fastq}{,.gz}"
   - ch_fasta:
-      description: Channel with genome sequence in fasta format
-      structure:
-        - meta:
-            type: map
-            description: Metadata for the fasta file
-        - fasta:
-            type: file
-            description: Genome fasta file
-            pattern: "*.{fa,fasta}"
+      type: file
+      description: |
+        Channel with genome sequence in fasta format.
+
+        Structure: [ val(meta), path(fasta) ]
+      pattern: "*.{fa,fasta}"
   - ch_transcript_fasta:
-      description: Channel with transcriptome sequence in fasta format
-      structure:
-        - meta:
-            type: map
-            description: Metadata for the transcript fasta file
-        - fasta:
-            type: file
-            description: Transcript fasta file
-            pattern: "*.{fa,fasta}"
+      type: file
+      description: |
+        Channel with transcriptome sequence in fasta format.
+
+        Structure: [ val(meta), path(fasta) ]
+      pattern: "*.{fa,fasta}"
   - ch_gtf:
-      description: Channel with features in GTF format
-      structure:
-        - meta:
-            type: map
-            description: Metadata for the GTF file
-        - gtf:
-            type: file
-            description: GTF file
-            pattern: "*.gtf"
+      type: file
+      description: |
+        Channel with features in GTF format.
+
+        Structure: [ val(meta), path(gtf) ]
+      pattern: "*.gtf"
   - ch_salmon_index:
-      description: Directory containing Salmon index
-      structure:
-        - meta:
-            type: map
-            description: Metadata for the Salmon index
-        - index:
-            type: directory
-            description: Salmon index directory
+      type: directory
+      description: |
+        Directory containing a Salmon index (optional).
+
+        Structure: [ val(meta), path(index) ]
   - ch_sortmerna_index:
-      description: Directory containing sortmerna index
-      structure:
-        - meta:
-            type: map
-            description: Metadata for the SortMeRNA index
-        - index:
-            type: directory
-            description: SortMeRNA index directory
+      type: directory
+      description: |
+        Directory containing a SortMeRNA index (optional).
+
+        Structure: [ val(meta), path(index) ]
   - ch_bowtie2_index:
-      description: Directory containing bowtie2 index for rRNA removal
-      structure:
-        - meta:
-            type: map
-            description: Metadata for the Bowtie2 index
-        - index:
-            type: directory
-            description: Bowtie2 index directory
+      type: directory
+      description: |
+        Directory containing a Bowtie2 index for rRNA removal (optional).
+
+        Structure: [ val(meta), path(index) ]
   - ch_bbsplit_index:
-      description: Path to directory or tar.gz archive for pre-built BBSplit index
-      structure:
-        - meta:
-            type: map
-            description: Metadata for the BBSplit index
-        - index:
-            type: file
-            description: BBSplit index directory or tar.gz archive
-            pattern: "{*,*.tar.gz}"
+      type: file
+      description: |
+        Path to directory or tar.gz archive for a pre-built BBSplit index (optional).
+
+        Structure: [ val(meta), path(index) ]
+      pattern: "{*,*.tar.gz}"
   - ch_rrna_fastas:
-      description: Channel containing one or more FASTA files containing rRNA sequences for use with SortMeRNA or Bowtie2
-      structure:
-        - meta:
-            type: map
-            description: Metadata for the rRNA fasta files
-        - fasta:
-            type: file
-            description: rRNA fasta files
-            pattern: "*.{fa,fasta}"
+      type: file
+      description: |
+        Channel containing one or more FASTA files containing rRNA sequences for use with
+        SortMeRNA or Bowtie2 (optional).
+
+        Structure: [ val(meta), path(fasta) ]
+      pattern: "*.{fa,fasta}"
   - skip_bbsplit:
       type: boolean
       description: Whether to skip BBSplit for removal of non-reference genome reads
@@ -155,6 +130,11 @@ input:
   - umi_discard_read:
       type: integer
       description: After UMI barcode extraction discard either R1 or R2 by setting this parameter to 1 or 2, respectively
+  - save_merged_fastq:
+      type: boolean
+      description: |
+        Pass single-library samples through cat/fastq as well, so that merged FastQ files
+        are saved even when there is nothing to merge
   - stranded_threshold:
       type: float
       min: 0.5
@@ -165,109 +145,236 @@ input:
 
 output:
   - reads:
-      description: Preprocessed fastq reads
-      structure:
-        - meta:
-            type: map
-            description: Metadata for the preprocessed reads
-        - reads:
-            type: file
-            description: Preprocessed FastQ files
-            pattern: "*.{fq,fastq},{,.gz}"
+      type: file
+      description: |
+        Preprocessed FastQ reads, with the inferred strandedness added to the meta map.
+
+        Structure: [ val(meta), [ path(reads) ] ]
+      pattern: "*.{fq,fastq}{,.gz}"
   - reads_cat:
-      description: Channel snapshot of reads before adapter trimming
-      structure:
-        - meta:
-            type: map
-            description: Groovy Map containing sample information
-        - reads:
-            type: file
-            description: Pre-trimming FastQ files
-            pattern: "*.{fq,fastq},{,.gz}"
+      type: file
+      description: |
+        Channel snapshot of reads before adapter trimming.
+
+        Structure: [ val(meta), [ path(reads) ] ]
+      pattern: "*.{fq,fastq}{,.gz}"
   - reads_trimmed:
-      description: Channel snapshot of reads after adapter trimming but before BBSplit/rRNA removal
-      structure:
-        - meta:
-            type: map
-            description: Groovy Map containing sample information
-        - reads:
-            type: file
-            description: Trimmed FastQ files prior to BBSplit/rRNA removal
-            pattern: "*.{fq,fastq},{,.gz}"
-  - multiqc_files:
-      description: MultiQC-compatible output files from tools used in preprocessing
-      structure:
-        - meta:
-            type: map
-            description: Metadata for the MultiQC files
-        - mqc:
-            type: file
-            description: MultiQC-compatible files
-            pattern: "*"
+      type: file
+      description: |
+        Channel snapshot of reads after adapter trimming but before BBSplit/rRNA removal.
+
+        Structure: [ val(meta), [ path(reads) ] ]
+      pattern: "*.{fq,fastq}{,.gz}"
   - trim_read_count:
-      description: Number of reads remaining after trimming for all input samples
-      structure:
-        - meta:
-            type: map
-            description: Metadata for the trim read count
-        - count:
-            type: integer
-            description: Number of reads after trimming
+      type: integer
+      description: |
+        Number of reads remaining after trimming for all input samples.
+
+        Structure: [ val(meta), val(count) ]
   - trim_reads_merged:
+      type: file
       description: |
         fastp's merged overlapping read pairs, produced only when `trimmer == 'fastp'` and
         `fastp_merge == true`. Empty otherwise. These reads are excluded from `reads`;
         callers that want to use them downstream must consume this channel separately.
-      structure:
-        - meta:
-            type: map
-            description: Metadata for the merged reads
-        - reads:
-            type: file
-            description: fastp merged FastQ file
-            pattern: "*.merged.fastq.gz"
-  - lint_log:
-      description: Log files from FastQ linting
-      structure:
-        - meta:
-            type: map
-            description: Metadata for the lint log
-        - log:
-            type: file
-            description: FastQ lint log file
-            pattern: "*.log"
-  - fastqc_filtered_html:
-      description: FastQC report HTML files for filtered reads (after BBSplit and/or rRNA removal)
-      structure:
-        - meta:
-            type: map
-            description: Groovy Map containing sample information
-        - html:
-            type: file
-            description: FastQC report HTML file
-            pattern: "*.html"
-  - fastqc_filtered_zip:
-      description: FastQC report ZIP files for filtered reads (after BBSplit and/or rRNA removal)
-      structure:
-        - meta:
-            type: map
-            description: Groovy Map containing sample information
-        - zip:
-            type: file
-            description: FastQC report ZIP file
-            pattern: "*.zip"
-  - per_sample_mqc_bundle:
+
+        Structure: [ val(meta), path(reads) ]
+      pattern: "*.merged.fastq.gz"
+  - multiqc_files:
+      type: file
       description: |
-        Per-sample MultiQC-feeding outputs (FastQC raw/trim/filtered zips,
-        trim log/JSON, UMI log, BBSplit stats, SortMeRNA log, RiboDetector
-        log, SeqKit stats, Bowtie2 log) joined on meta.
-      structure:
-        - meta:
-            type: map
-            description: Groovy Map containing sample information
-        - files:
-            type: file
-            description: List of MultiQC-relevant files for the sample
+        MultiQC-compatible output files from tools used in preprocessing, one file per item.
+
+        Structure: [ val(meta), path(mqc) ]
+  - lint_log_raw:
+      type: file
+      description: |
+        fq lint log for the raw reads, only populated when linting is not skipped.
+
+        Structure: [ val(meta), path(log) ]
+      pattern: "*.log"
+  - lint_log_trimmed:
+      type: file
+      description: |
+        fq lint log for the trimmed reads, only populated when linting and trimming are
+        both performed.
+
+        Structure: [ val(meta), path(log) ]
+      pattern: "*.log"
+  - lint_log_bbsplit:
+      type: file
+      description: |
+        fq lint log for the reads after BBSplit, only populated when linting is not skipped
+        and BBSplit is run.
+
+        Structure: [ val(meta), path(log) ]
+      pattern: "*.log"
+  - lint_log_ribo:
+      type: file
+      description: |
+        fq lint log for the reads after rRNA removal, only populated when linting is not
+        skipped and rRNA removal is run.
+
+        Structure: [ val(meta), path(log) ]
+      pattern: "*.log"
+  - fastqc_raw_html:
+      type: file
+      description: |
+        FastQC report for the raw reads.
+
+        Structure: [ val(meta), [ path(html) ] ]
+      pattern: "*_fastqc.html"
+  - fastqc_raw_zip:
+      type: file
+      description: |
+        FastQC report archive for the raw reads.
+
+        Structure: [ val(meta), [ path(zip) ] ]
+      pattern: "*_fastqc.zip"
+  - fastqc_trim_html:
+      type: file
+      description: |
+        FastQC report for the trimmed reads.
+
+        Structure: [ val(meta), [ path(html) ] ]
+      pattern: "*_fastqc.html"
+  - fastqc_trim_zip:
+      type: file
+      description: |
+        FastQC report archive for the trimmed reads.
+
+        Structure: [ val(meta), [ path(zip) ] ]
+      pattern: "*_fastqc.zip"
+  - trim_html:
+      type: file
+      description: |
+        FastP trimming report, only populated when fastp is the trimmer.
+
+        Structure: [ val(meta), path(html) ]
+      pattern: "*.fastp.html"
+  - trim_zip:
+      type: file
+      description: |
+        Trim Galore! report archive. Reserved for the trimgalore path and not currently
+        populated.
+
+        Structure: [ val(meta), [ path(zip) ] ]
+  - trim_log:
+      type: file
+      description: |
+        Trimming report from FastP or Trim Galore!, depending on the trimmer.
+
+        Structure: [ val(meta), [ path(log) ] ]
+  - trim_json:
+      type: file
+      description: |
+        FastP trimming report in JSON format, only populated when fastp is the trimmer.
+
+        Structure: [ val(meta), path(json) ]
+      pattern: "*.fastp.json"
+  - trim_unpaired:
+      type: file
+      description: |
+        FastQ files containing unpaired reads from read 1 or read 2, only populated when
+        trimgalore is the trimmer.
+
+        Structure: [ val(meta), [ path(reads) ] ]
+      pattern: "*unpaired*.fq.gz"
+  - umi_log:
+      type: file
+      description: |
+        Logfile for umi_tools extract, only populated when UMI extraction is performed.
+
+        Structure: [ val(meta), path(log) ]
+      pattern: "*.log"
+  - umi_reads:
+      type: file
+      description: |
+        UMI-extracted FastQ files, before trimming.
+
+        Structure: [ val(meta), [ path(reads) ] ]
+      pattern: "*.fastq.gz"
+  - bbsplit_stats:
+      type: file
+      description: |
+        BBSplit statistics, only populated when BBSplit is run.
+
+        Structure: [ val(meta), path(stats) ]
+      pattern: "*.txt"
+  - sortmerna_log:
+      type: file
+      description: |
+        SortMeRNA log file, only populated when sortmerna is the rRNA removal tool.
+
+        Structure: [ val(meta), path(log) ]
+      pattern: "*.log"
+  - ribodetector_log:
+      type: file
+      description: |
+        RiboDetector log file, only populated when ribodetector is the rRNA removal tool.
+
+        Structure: [ val(meta), path(log) ]
+      pattern: "*.log"
+  - seqkit_stats:
+      type: file
+      description: |
+        SeqKit statistics used to derive the mean read length for RiboDetector, only
+        populated when ribodetector is the rRNA removal tool.
+
+        Structure: [ val(meta), path(stats) ]
+      pattern: "*.tsv"
+  - bowtie2_log:
+      type: file
+      description: |
+        Bowtie2 alignment log files, only populated when bowtie2 is the rRNA removal tool.
+
+        Structure: [ val(meta), path(log) ]
+      pattern: "*.log"
+  - bowtie2_index:
+      type: directory
+      description: |
+        Bowtie2 index built from the rRNA references, only populated when bowtie2 is the
+        rRNA removal tool and make_bowtie2_index is true.
+
+        Structure: [ val(meta), path(index) ]
+  - fastqc_filtered_html:
+      type: file
+      description: |
+        FastQC report HTML files for filtered reads (after BBSplit and/or rRNA removal).
+
+        Structure: [ val(meta), [ path(html) ] ]
+      pattern: "*.html"
+  - fastqc_filtered_zip:
+      type: file
+      description: |
+        FastQC report ZIP files for filtered reads (after BBSplit and/or rRNA removal).
+
+        Structure: [ val(meta), [ path(zip) ] ]
+      pattern: "*.zip"
+  - seqkit_prefixed:
+      type: file
+      description: |
+        rRNA reference fasta files with their filename added as a prefix to each sequence
+        header, only populated when a Bowtie2 index is built.
+
+        Structure: [ val(meta), path(fasta) ]
+      pattern: "*.{fa,fasta}{,.gz}"
+  - seqkit_converted:
+      type: file
+      description: |
+        Prefixed rRNA reference fasta files with U bases converted to T, only populated
+        when a Bowtie2 index is built.
+
+        Structure: [ val(meta), path(fasta) ]
+      pattern: "*.{fa,fasta}{,.gz}"
+  - per_sample_mqc_bundle:
+      type: file
+      description: |
+        Per-sample MultiQC-feeding outputs (FastQC raw/trim/filtered zips, trim log/JSON,
+        UMI log, BBSplit stats, SortMeRNA log, RiboDetector log, SeqKit stats, Bowtie2
+        log) joined on meta.
+
+        Structure: [ val(meta), [ path(files) ] ]
 
 authors:
   - "@pinin4fjords"

--- a/subworkflows/nf-core/orftable_fasta_gtf_buildorfcatalogue/main.nf
+++ b/subworkflows/nf-core/orftable_fasta_gtf_buildorfcatalogue/main.nf
@@ -32,12 +32,13 @@ workflow ORFTABLE_FASTA_GTF_BUILDORFCATALOGUE {
 
     // 1. Normalise each caller's output. The same module is invoked once per
     //    input emission; dispatch happens inside the template based on the
-    //    `caller` val. Append the caller to meta.id so the normaliser's
-    //    default `${meta.id}` prefix yields caller-disambiguated filenames
+    //    `caller` val. Stash it in `meta.caller` too so this subworkflow's own
+    //    `ext.prefix` config can disambiguate output filenames per caller
     //    (the merger stages multiple BED12s into `beds/*` and needs unique
-    //    names per caller-sample combination).
+    //    names per caller-sample combination) while meta.id keeps carrying
+    //    the true sample id through to CUSTOM_ORFNORMALISE's sample_id column.
     ch_normalise_in = ch_orf_tables.map { meta, table, caller ->
-        [ meta + [ id: "${meta.id}.${caller}" ], table, caller ]
+        [ meta + [ caller: caller ], table, caller ]
     }
     CUSTOM_ORFNORMALISE ( ch_normalise_in, ch_gtf.first() )
 

--- a/subworkflows/nf-core/orftable_fasta_gtf_buildorfcatalogue/main.nf
+++ b/subworkflows/nf-core/orftable_fasta_gtf_buildorfcatalogue/main.nf
@@ -32,15 +32,12 @@ workflow ORFTABLE_FASTA_GTF_BUILDORFCATALOGUE {
 
     // 1. Normalise each caller's output. The same module is invoked once per
     //    input emission; dispatch happens inside the template based on the
-    //    `caller` val. Stash it in `meta.caller` too so this subworkflow's own
-    //    `ext.prefix` config can disambiguate output filenames per caller
-    //    (the merger stages multiple BED12s into `beds/*` and needs unique
-    //    names per caller-sample combination) while meta.id keeps carrying
-    //    the true sample id through to CUSTOM_ORFNORMALISE's sample_id column.
-    ch_normalise_in = ch_orf_tables.map { meta, table, caller ->
-        [ meta + [ caller: caller ], table, caller ]
-    }
-    CUSTOM_ORFNORMALISE ( ch_normalise_in, ch_gtf.first() )
+    //    `caller` val, which this subworkflow's own `ext.prefix` config also
+    //    reads directly to disambiguate output filenames per caller (the
+    //    merger stages multiple BED12s into `beds/*` and needs unique names
+    //    per caller-sample combination). meta.id keeps carrying the true
+    //    sample id through to CUSTOM_ORFNORMALISE's sample_id column.
+    CUSTOM_ORFNORMALISE ( ch_orf_tables, ch_gtf.first() )
 
     // 2. Gather all normalised BED12s + sidecar TSVs across callers and
     //    samples into a single cohort-keyed channel. `.collect()` on an

--- a/subworkflows/nf-core/orftable_fasta_gtf_buildorfcatalogue/nextflow.config
+++ b/subworkflows/nf-core/orftable_fasta_gtf_buildorfcatalogue/nextflow.config
@@ -1,4 +1,7 @@
 process {
+    withName: '.*ORFTABLE_FASTA_GTF_BUILDORFCATALOGUE:CUSTOM_ORFNORMALISE' {
+        ext.prefix = { "${meta.id}.${meta.caller}.normalised" }
+    }
     withName: '.*ORFTABLE_FASTA_GTF_BUILDORFCATALOGUE:BEDTOOLS_GETFASTA' {
         ext.prefix = { "${meta.id}.catalogue.nt" }
         ext.args   = '-split -s -nameOnly'

--- a/subworkflows/nf-core/orftable_fasta_gtf_buildorfcatalogue/nextflow.config
+++ b/subworkflows/nf-core/orftable_fasta_gtf_buildorfcatalogue/nextflow.config
@@ -1,6 +1,6 @@
 process {
     withName: '.*ORFTABLE_FASTA_GTF_BUILDORFCATALOGUE:CUSTOM_ORFNORMALISE' {
-        ext.prefix = { "${meta.id}.${meta.caller}.normalised" }
+        ext.prefix = { "${meta.id}.${caller}.normalised" }
     }
     withName: '.*ORFTABLE_FASTA_GTF_BUILDORFCATALOGUE:BEDTOOLS_GETFASTA' {
         ext.prefix = { "${meta.id}.catalogue.nt" }

--- a/tests/dotseq.nf.test.snap
+++ b/tests/dotseq.nf.test.snap
@@ -1786,22 +1786,22 @@
                 "cohort.catalogue.fasta:md5,6f0830db2ccdec755dd20fc73627cd22",
                 "cohort.catalogue.mqc.tsv:md5,9a06955756b1c77489402a159823770b",
                 "cohort.catalogue.orf_to_gene.tsv:md5,44964ac37a6e9e339b93d99bf8e7a1ff",
-                "cohort.catalogue.tsv:md5,7ffee8acc8851bb9dc5857f1376268ed",
+                "cohort.catalogue.tsv:md5,444d16d02463a5599afa9874a3027add",
                 "cohort.catalogue.consensus.bed12:md5,158089eaa1ebf9c88d47247f7f459c45",
                 "cohort.catalogue.consensus.orf_to_gene.tsv:md5,44964ac37a6e9e339b93d99bf8e7a1ff",
-                "cohort.catalogue.consensus.tsv:md5,7ffee8acc8851bb9dc5857f1376268ed",
+                "cohort.catalogue.consensus.tsv:md5,444d16d02463a5599afa9874a3027add",
                 "SRX11780885.ribotish.normalised.bed12:md5,9ded56eb8dc1f6ac54f32f7b75191910",
-                "SRX11780885.ribotish.normalised.tsv:md5,efb7915d8d936f52a5f7887edc76b986",
+                "SRX11780885.ribotish.normalised.tsv:md5,720d616ab83b710bd194a2df7ef03eb9",
                 "SRX11780886.ribotish.normalised.bed12:md5,f3d79b0905fb064eacea7a4c786e6a9e",
-                "SRX11780886.ribotish.normalised.tsv:md5,0a559fd03950f3e1cf2b30efeb5ec5c4",
+                "SRX11780886.ribotish.normalised.tsv:md5,87254ecdc9fea4b43c3f6a06da8211f6",
                 "SRX11780887.ribotish.normalised.bed12:md5,71f7540a0b7b72ad0fba6d0efb600df4",
-                "SRX11780887.ribotish.normalised.tsv:md5,7eca9d5e8b5702f92e7839f6a0750c57",
+                "SRX11780887.ribotish.normalised.tsv:md5,8b5c0e23fec34cddeadc1b9535c299d8",
                 "SRX11780888.ribotish.normalised.bed12:md5,0cbae09fb77c8221e78a3090106b5e17",
-                "SRX11780888.ribotish.normalised.tsv:md5,1e2f5891d7db52f1afb8606f34104983",
+                "SRX11780888.ribotish.normalised.tsv:md5,ff895057dd023c965dd4749d9c649172",
                 "SRX11780889.ribotish.normalised.bed12:md5,614fe652a2ee788b594e05330f86ddf5",
-                "SRX11780889.ribotish.normalised.tsv:md5,bbec3954df818e7f63b4814db84a5189",
+                "SRX11780889.ribotish.normalised.tsv:md5,d54ecc43434bf35c5355247017f2280a",
                 "SRX11780890.ribotish.normalised.bed12:md5,220eaac88be55768233c637f3e3cbe79",
-                "SRX11780890.ribotish.normalised.tsv:md5,eacff97dfb3e6bbfb333c7cefb59fdd4",
+                "SRX11780890.ribotish.normalised.tsv:md5,7eebec0bc1a6fcf83b6df7cfb821b5d7",
                 "SRX11780885_all.txt:md5,24ec9214a89c2285fd7d338430b95226",
                 "SRX11780885_pred.txt:md5,24ec9214a89c2285fd7d338430b95226",
                 "SRX11780886_all.txt:md5,aef11a9444b5a51ddd850b5b201a1ec8",
@@ -1978,10 +1978,10 @@
                 "SRX11780890_qual.txt:md5,9caaf68044fd714a3265f63c920e75d5"
             ]
         ],
-        "timestamp": "2026-08-10T16:39:54.61386102",
+        "timestamp": "2026-09-06T23:31:24.797082212",
         "meta": {
-            "nf-test": "0.9.4",
-            "nextflow": "25.10.4"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
         }
     }
 }

--- a/tests/novel_gtf.nf.test.snap
+++ b/tests/novel_gtf.nf.test.snap
@@ -1795,22 +1795,22 @@
                 "cohort.catalogue.fasta:md5,6f0830db2ccdec755dd20fc73627cd22",
                 "cohort.catalogue.mqc.tsv:md5,9a06955756b1c77489402a159823770b",
                 "cohort.catalogue.orf_to_gene.tsv:md5,44964ac37a6e9e339b93d99bf8e7a1ff",
-                "cohort.catalogue.tsv:md5,7ffee8acc8851bb9dc5857f1376268ed",
+                "cohort.catalogue.tsv:md5,444d16d02463a5599afa9874a3027add",
                 "cohort.catalogue.consensus.bed12:md5,158089eaa1ebf9c88d47247f7f459c45",
                 "cohort.catalogue.consensus.orf_to_gene.tsv:md5,44964ac37a6e9e339b93d99bf8e7a1ff",
-                "cohort.catalogue.consensus.tsv:md5,7ffee8acc8851bb9dc5857f1376268ed",
+                "cohort.catalogue.consensus.tsv:md5,444d16d02463a5599afa9874a3027add",
                 "SRX11780885.ribotish.normalised.bed12:md5,9ded56eb8dc1f6ac54f32f7b75191910",
-                "SRX11780885.ribotish.normalised.tsv:md5,efb7915d8d936f52a5f7887edc76b986",
+                "SRX11780885.ribotish.normalised.tsv:md5,720d616ab83b710bd194a2df7ef03eb9",
                 "SRX11780886.ribotish.normalised.bed12:md5,f3d79b0905fb064eacea7a4c786e6a9e",
-                "SRX11780886.ribotish.normalised.tsv:md5,0a559fd03950f3e1cf2b30efeb5ec5c4",
+                "SRX11780886.ribotish.normalised.tsv:md5,87254ecdc9fea4b43c3f6a06da8211f6",
                 "SRX11780887.ribotish.normalised.bed12:md5,71f7540a0b7b72ad0fba6d0efb600df4",
-                "SRX11780887.ribotish.normalised.tsv:md5,7eca9d5e8b5702f92e7839f6a0750c57",
+                "SRX11780887.ribotish.normalised.tsv:md5,8b5c0e23fec34cddeadc1b9535c299d8",
                 "SRX11780888.ribotish.normalised.bed12:md5,0cbae09fb77c8221e78a3090106b5e17",
-                "SRX11780888.ribotish.normalised.tsv:md5,1e2f5891d7db52f1afb8606f34104983",
+                "SRX11780888.ribotish.normalised.tsv:md5,ff895057dd023c965dd4749d9c649172",
                 "SRX11780889.ribotish.normalised.bed12:md5,614fe652a2ee788b594e05330f86ddf5",
-                "SRX11780889.ribotish.normalised.tsv:md5,bbec3954df818e7f63b4814db84a5189",
+                "SRX11780889.ribotish.normalised.tsv:md5,d54ecc43434bf35c5355247017f2280a",
                 "SRX11780890.ribotish.normalised.bed12:md5,220eaac88be55768233c637f3e3cbe79",
-                "SRX11780890.ribotish.normalised.tsv:md5,eacff97dfb3e6bbfb333c7cefb59fdd4",
+                "SRX11780890.ribotish.normalised.tsv:md5,7eebec0bc1a6fcf83b6df7cfb821b5d7",
                 "SRX11780885_all.txt:md5,24ec9214a89c2285fd7d338430b95226",
                 "SRX11780885_pred.txt:md5,24ec9214a89c2285fd7d338430b95226",
                 "SRX11780886_all.txt:md5,aef11a9444b5a51ddd850b5b201a1ec8",
@@ -1988,10 +1988,10 @@
                 "novel_gtf_filtered.gtf:md5,4e9a0d071f3b6ef0876a5fb429bde8d8"
             ]
         ],
-        "timestamp": "2026-08-10T16:39:33.573156264",
+        "timestamp": "2026-09-07T00:50:00.511216698",
         "meta": {
-            "nf-test": "0.9.4",
-            "nextflow": "25.10.4"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
         }
     }
 }

--- a/tests/orf_catalogue_no_novel_source.nf.test.snap
+++ b/tests/orf_catalogue_no_novel_source.nf.test.snap
@@ -1551,22 +1551,22 @@
                 "cohort.catalogue.fasta:md5,6f0830db2ccdec755dd20fc73627cd22",
                 "cohort.catalogue.mqc.tsv:md5,9a06955756b1c77489402a159823770b",
                 "cohort.catalogue.orf_to_gene.tsv:md5,d0135c797559a3547b68e3df83b1d773",
-                "cohort.catalogue.tsv:md5,7ffee8acc8851bb9dc5857f1376268ed",
+                "cohort.catalogue.tsv:md5,444d16d02463a5599afa9874a3027add",
                 "cohort.catalogue.consensus.bed12:md5,158089eaa1ebf9c88d47247f7f459c45",
                 "cohort.catalogue.consensus.orf_to_gene.tsv:md5,d0135c797559a3547b68e3df83b1d773",
-                "cohort.catalogue.consensus.tsv:md5,7ffee8acc8851bb9dc5857f1376268ed",
+                "cohort.catalogue.consensus.tsv:md5,444d16d02463a5599afa9874a3027add",
                 "SRX11780885.ribotish.normalised.bed12:md5,35b49388596a42931117dbf690ba63e3",
-                "SRX11780885.ribotish.normalised.tsv:md5,ca12c34392b171d7598fee4d220950f8",
+                "SRX11780885.ribotish.normalised.tsv:md5,621faa7b0477de1c8a418b6c084c9424",
                 "SRX11780886.ribotish.normalised.bed12:md5,f3d79b0905fb064eacea7a4c786e6a9e",
-                "SRX11780886.ribotish.normalised.tsv:md5,0a559fd03950f3e1cf2b30efeb5ec5c4",
+                "SRX11780886.ribotish.normalised.tsv:md5,87254ecdc9fea4b43c3f6a06da8211f6",
                 "SRX11780887.ribotish.normalised.bed12:md5,41799a2b713a0d8889f9925996160f89",
-                "SRX11780887.ribotish.normalised.tsv:md5,25d7c3fcd4f018961cec0f2fb1d88728",
+                "SRX11780887.ribotish.normalised.tsv:md5,f568f2c71b88cf64c80fc2ddec76f508",
                 "SRX11780888.ribotish.normalised.bed12:md5,dd10c50302d6bf6d9fa18826834546ed",
-                "SRX11780888.ribotish.normalised.tsv:md5,93394ce516d50a3705725b042d672865",
+                "SRX11780888.ribotish.normalised.tsv:md5,6be91c59fbf0ab148684a909ff924fc9",
                 "SRX11780889.ribotish.normalised.bed12:md5,b1d78a807d76d1b21e854632270d92af",
-                "SRX11780889.ribotish.normalised.tsv:md5,dc13eed9d63aeb0526fb1b0aaf9e69b3",
+                "SRX11780889.ribotish.normalised.tsv:md5,c807be881c4979bf591658d86fed98ef",
                 "SRX11780890.ribotish.normalised.bed12:md5,4d1f1b565c5d0ee49a692eba6ed9b10a",
-                "SRX11780890.ribotish.normalised.tsv:md5,ba0b302ace1df3532e9be08adde88f2b",
+                "SRX11780890.ribotish.normalised.tsv:md5,a29b5393ed0779ccca5e0483ed8d356d",
                 "SRX11780885_all.txt:md5,96bc42211790337d7e9c90d24ebe1a32",
                 "SRX11780885_pred.txt:md5,96bc42211790337d7e9c90d24ebe1a32",
                 "SRX11780886_all.txt:md5,aef11a9444b5a51ddd850b5b201a1ec8",
@@ -1725,10 +1725,10 @@
                 "SRX11780890_qual.txt:md5,9caaf68044fd714a3265f63c920e75d5"
             ]
         ],
-        "timestamp": "2026-08-10T16:27:11.894372767",
+        "timestamp": "2026-09-06T23:15:30.655412488",
         "meta": {
-            "nf-test": "0.9.4",
-            "nextflow": "25.10.4"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
         }
     }
 }

--- a/tests/stringtie_extended.nf.test.snap
+++ b/tests/stringtie_extended.nf.test.snap
@@ -1808,22 +1808,22 @@
                 "cohort.catalogue.fasta:md5,6f0830db2ccdec755dd20fc73627cd22",
                 "cohort.catalogue.mqc.tsv:md5,9a06955756b1c77489402a159823770b",
                 "cohort.catalogue.orf_to_gene.tsv:md5,44964ac37a6e9e339b93d99bf8e7a1ff",
-                "cohort.catalogue.tsv:md5,7ffee8acc8851bb9dc5857f1376268ed",
+                "cohort.catalogue.tsv:md5,444d16d02463a5599afa9874a3027add",
                 "cohort.catalogue.consensus.bed12:md5,158089eaa1ebf9c88d47247f7f459c45",
                 "cohort.catalogue.consensus.orf_to_gene.tsv:md5,44964ac37a6e9e339b93d99bf8e7a1ff",
-                "cohort.catalogue.consensus.tsv:md5,7ffee8acc8851bb9dc5857f1376268ed",
+                "cohort.catalogue.consensus.tsv:md5,444d16d02463a5599afa9874a3027add",
                 "SRX11780885.ribotish.normalised.bed12:md5,9ded56eb8dc1f6ac54f32f7b75191910",
-                "SRX11780885.ribotish.normalised.tsv:md5,efb7915d8d936f52a5f7887edc76b986",
+                "SRX11780885.ribotish.normalised.tsv:md5,720d616ab83b710bd194a2df7ef03eb9",
                 "SRX11780886.ribotish.normalised.bed12:md5,f3d79b0905fb064eacea7a4c786e6a9e",
-                "SRX11780886.ribotish.normalised.tsv:md5,0a559fd03950f3e1cf2b30efeb5ec5c4",
+                "SRX11780886.ribotish.normalised.tsv:md5,87254ecdc9fea4b43c3f6a06da8211f6",
                 "SRX11780887.ribotish.normalised.bed12:md5,71f7540a0b7b72ad0fba6d0efb600df4",
-                "SRX11780887.ribotish.normalised.tsv:md5,7eca9d5e8b5702f92e7839f6a0750c57",
+                "SRX11780887.ribotish.normalised.tsv:md5,8b5c0e23fec34cddeadc1b9535c299d8",
                 "SRX11780888.ribotish.normalised.bed12:md5,0cbae09fb77c8221e78a3090106b5e17",
-                "SRX11780888.ribotish.normalised.tsv:md5,1e2f5891d7db52f1afb8606f34104983",
+                "SRX11780888.ribotish.normalised.tsv:md5,ff895057dd023c965dd4749d9c649172",
                 "SRX11780889.ribotish.normalised.bed12:md5,614fe652a2ee788b594e05330f86ddf5",
-                "SRX11780889.ribotish.normalised.tsv:md5,bbec3954df818e7f63b4814db84a5189",
+                "SRX11780889.ribotish.normalised.tsv:md5,d54ecc43434bf35c5355247017f2280a",
                 "SRX11780890.ribotish.normalised.bed12:md5,220eaac88be55768233c637f3e3cbe79",
-                "SRX11780890.ribotish.normalised.tsv:md5,eacff97dfb3e6bbfb333c7cefb59fdd4",
+                "SRX11780890.ribotish.normalised.tsv:md5,7eebec0bc1a6fcf83b6df7cfb821b5d7",
                 "SRX11780885_all.txt:md5,24ec9214a89c2285fd7d338430b95226",
                 "SRX11780885_pred.txt:md5,24ec9214a89c2285fd7d338430b95226",
                 "SRX11780886_all.txt:md5,aef11a9444b5a51ddd850b5b201a1ec8",
@@ -2000,10 +2000,10 @@
                 "SRX11780890_qual.txt:md5,9caaf68044fd714a3265f63c920e75d5"
             ]
         ],
-        "timestamp": "2026-08-10T16:38:14.245170516",
+        "timestamp": "2026-09-06T22:48:04.403025276",
         "meta": {
-            "nf-test": "0.9.4",
-            "nextflow": "25.10.4"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
         }
     }
 }

--- a/tests/umi_extended_orf.nf.test.snap
+++ b/tests/umi_extended_orf.nf.test.snap
@@ -1651,22 +1651,22 @@
                 "cohort.catalogue.fasta:md5,6926c6385abc9c3c54773ca98bb424ea",
                 "cohort.catalogue.mqc.tsv:md5,c8b1a375e5fd4dbdf70a25299d57e28b",
                 "cohort.catalogue.orf_to_gene.tsv:md5,453474ab0d70cebf8056777ecb24c998",
-                "cohort.catalogue.tsv:md5,1de90758e4e0e49f7206e2a78f8180ed",
+                "cohort.catalogue.tsv:md5,19fcaf3e14e2c8f39e356746b8231b8e",
                 "cohort.catalogue.consensus.bed12:md5,0b7b47ca5d3c8408a63301da6ddcfe5d",
                 "cohort.catalogue.consensus.orf_to_gene.tsv:md5,453474ab0d70cebf8056777ecb24c998",
-                "cohort.catalogue.consensus.tsv:md5,1de90758e4e0e49f7206e2a78f8180ed",
+                "cohort.catalogue.consensus.tsv:md5,19fcaf3e14e2c8f39e356746b8231b8e",
                 "SRX11780885.ribotish.normalised.bed12:md5,d41d8cd98f00b204e9800998ecf8427e",
                 "SRX11780885.ribotish.normalised.tsv:md5,c8b443b91724ffad37fd7758ad63fc2d",
                 "SRX11780886.ribotish.normalised.bed12:md5,f3d79b0905fb064eacea7a4c786e6a9e",
-                "SRX11780886.ribotish.normalised.tsv:md5,0a559fd03950f3e1cf2b30efeb5ec5c4",
+                "SRX11780886.ribotish.normalised.tsv:md5,87254ecdc9fea4b43c3f6a06da8211f6",
                 "SRX11780887.ribotish.normalised.bed12:md5,71f7540a0b7b72ad0fba6d0efb600df4",
-                "SRX11780887.ribotish.normalised.tsv:md5,7eca9d5e8b5702f92e7839f6a0750c57",
+                "SRX11780887.ribotish.normalised.tsv:md5,8b5c0e23fec34cddeadc1b9535c299d8",
                 "SRX11780888.ribotish.normalised.bed12:md5,0cbae09fb77c8221e78a3090106b5e17",
-                "SRX11780888.ribotish.normalised.tsv:md5,1e2f5891d7db52f1afb8606f34104983",
+                "SRX11780888.ribotish.normalised.tsv:md5,ff895057dd023c965dd4749d9c649172",
                 "SRX11780889.ribotish.normalised.bed12:md5,614fe652a2ee788b594e05330f86ddf5",
-                "SRX11780889.ribotish.normalised.tsv:md5,bbec3954df818e7f63b4814db84a5189",
+                "SRX11780889.ribotish.normalised.tsv:md5,d54ecc43434bf35c5355247017f2280a",
                 "SRX11780890.ribotish.normalised.bed12:md5,220eaac88be55768233c637f3e3cbe79",
-                "SRX11780890.ribotish.normalised.tsv:md5,eacff97dfb3e6bbfb333c7cefb59fdd4",
+                "SRX11780890.ribotish.normalised.tsv:md5,7eebec0bc1a6fcf83b6df7cfb821b5d7",
                 "SRX11780885_all.txt:md5,5b20c196f6f55f78bc4984d00c602892",
                 "SRX11780885_pred.txt:md5,5b20c196f6f55f78bc4984d00c602892",
                 "SRX11780886_all.txt:md5,aef11a9444b5a51ddd850b5b201a1ec8",
@@ -1753,10 +1753,10 @@
                 "SRX11780890_qual.txt:md5,9caaf68044fd714a3265f63c920e75d5"
             ]
         ],
-        "timestamp": "2026-08-10T23:16:24.620487912",
+        "timestamp": "2026-09-06T23:04:59.102601775",
         "meta": {
-            "nf-test": "0.9.4",
-            "nextflow": "25.10.4"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes for bugs found while adversarially reviewing #234 (the v2.0.0 release PR) before merging it. Each fix is verified with module-level nf-test and a full pipeline-level nf-test run on real (chr20) data.

Two fixes are also merged upstream in nf-core/modules ([#12895](https://github.com/nf-core/modules/pull/12895), [#12896](https://github.com/nf-core/modules/pull/12896)); `modules.json` here points at those merged commits.

## What changed

- `--skip_gtf_transcript_filter`'s `ext.args` used `?:` instead of `? :`, so the check was skipped by default and crashed if explicitly enabled. Fixed.
- Gene-level `DESEQ2_DELTATE` passed `--samples_batch_col`, a flag its R script doesn't recognise (`--batch_col` does, and the ORF-level sibling already had it right). Any run with a batch column crashed.
- `deseq2_deltate.R` fit the interaction model on the whole sample sheet instead of subsetting to the two contrast levels, unlike anota2seq/DOTSeq. Harmless with only two levels, wrong with 3+ levels sharing a `contrast_variable`. Now subsets like the others do.
- `orf_count_matrix`: a sample with zero P-sites produced an empty file with no `sample_id`, so it vanished from the matrix instead of showing as zero-filled. Now takes the expected sample list explicitly (JSON+base64-encoded, so it survives commas/quotes in sample ids).
- `quantify_orf_psite`: simplified sample-id/TSV collection to one `.collect(flat: false)` pass instead of two separate channel subscriptions.
- `RIBOCODE_METAPLOTS` exits 1 on sparse periodicity data, aborting the whole run, even though `orf_caller_dispatch` already has warn-and-skip logic for exactly that case. Added `errorStrategy = 'ignore'` so it actually fires.
- Reverted the temporary GitHub-hosted CI runner swap back to the self-hosted fleet. GitHub's `ubuntu-latest` now blocks unprivileged user namespaces, which breaks Singularity outright.
- Two upstream nf-core/modules fixes (linked above), synced here.

## Test plan

- [x] Module-level nf-test for every fix
- [x] Full pipeline nf-test (`deltate`, `dotseq`, `stringtie_extended`, `umi_extended_orf`, `orf_catalogue_no_novel_source`, `novel_gtf`) on chr20 data
- [x] `default.nf.test` unaffected
- [x] Adversarial review pass on every fix
